### PR TITLE
Refactored getPlayerMatchHistory and createPracticeLobby + externalized option parsing

### DIFF
--- a/handlers/community.js
+++ b/handlers/community.js
@@ -1,10 +1,18 @@
 var Dota2 = require("../index"),
     util = require("util");
 
+Dota2._playerHistoryOptions = {
+    start_at_match_id: "number",
+    matches_requested: "number",
+    hero_id: "number",
+    request_id: "number"
+  };
+
 // Methods
 
-Dota2.Dota2Client.prototype.getPlayerMatchHistory = function(account_id, match_id, callback) {
+Dota2.Dota2Client.prototype.getPlayerMatchHistory = function(account_id, filter, callback) {
   callback = callback || null;
+  filter = filter || null;
   var _self = this;
   /* Sends a message to the Game Coordinator requesting `accountId`'s player match history.  Listen for `playerMatchHistoryData` event for Game Coordinator's response. */
   if (!this._gcReady) {
@@ -13,13 +21,11 @@ Dota2.Dota2Client.prototype.getPlayerMatchHistory = function(account_id, match_i
   }
 
   if (this.debug) util.log("Sending player match history request");
-  var payload = new Dota2.schema.CMsgDOTAGetPlayerMatchHistory({
-      "account_id": account_id,
-      "start_at_match_id": match_id,
-      "matches_requested": 13,
-      "hero_id": 0,
-      "request_id": account_id
-  });
+  var command = Dota2._parseOptions(filter, Dota2._playerHistoryOptions);
+  command.account_id = account_id;
+  command.matches_requested = command.matches_requested || 1;
+  command.request_id = command.request_id || account_id;
+  var payload = new Dota2.schema.CMsgDOTAGetPlayerMatchHistory(command);
   this._protoBufHeader.msg = Dota2.EDOTAGCMsg.k_EMsgDOTAGetPlayerMatchHistory;
   this._gc.send(this._protoBufHeader,
                 payload.toBuffer(),

--- a/handlers/helper.js
+++ b/handlers/helper.js
@@ -1,0 +1,29 @@
+var Dota2 = require("../index"),
+    util = require("util");
+    
+// Helper methods
+Dota2._parseOptions = function(options, possibleOptions) {
+  var details, option, type, value;
+
+  details = {};
+
+  for (option in options) {
+    value = options[option];
+    type = possibleOptions[option];
+    if (type == null) {
+      if (this.debug) {
+        util.log("Option " + option + " is not possible.");
+      }
+      continue;
+    }
+    if (typeof value !== type) {
+      if (this.debug) {
+        util.log("Option " + option + " must be a " + type + ".");
+      }
+      continue;
+    }
+    details[option] = value;
+  }
+
+  return details;
+}

--- a/index.js
+++ b/index.js
@@ -216,3 +216,4 @@ require("./handlers/lobbies");
 //require("./handlers/parties");
 require("./handlers/leagues");
 require("./handlers/sourcetv");
+require("./handlers/helper");


### PR DESCRIPTION
I externalized the option parser from the configureLobby method in a separate file -> handlers/helper.js. createPracticeLobby, configureLobby and getPlayerMatchHistory all use this method to parse their input arguments. I made sure that all obligatory arguments are required on their respective interfaces.