### PR TITLE
Fix cache bug + always return channel_name instead of mix of ids and names

### DIFF
--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -2,6 +2,28 @@ var Dota2 = require("../index"),
     util = require("util");
 
 // Methods
+Dota2.Dota2Client.prototype._getChannelByName = function(channel_name) {
+  // Returns the channel_name correspondig to the given channel_id
+  if (this.chatChannels) {
+    return this.chatChannels.filter(
+        function (item) { return (item.channel_name === channel_name); }
+      )[0];
+  } else {
+    return null;
+  }
+}
+
+Dota2.Dota2Client.prototype._getChannelById = function(channel_id) {
+  // Returns the channel_name correspondig to the given channel_id
+  if (this.chatChannels) {
+    return this.chatChannels.filter(
+        // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
+        function (item) { return (""+item.channel_id === ""+channel_id); }
+      )[0];
+  } else {
+    return null;
+  }
+}
 
 Dota2.Dota2Client.prototype.joinChat = function(channel, type) {
   type = type || Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom;
@@ -31,7 +53,7 @@ Dota2.Dota2Client.prototype.leaveChat = function(channel) {
   }
 
   if (this.debug) util.log("Leaving chat channel: " + channel);
-  var channelId = this.chatChannels.filter(function (item) {return (item.channel_name == channel); }).map(function (item) { return item.channel_id; })[0]
+  var channelId = this._getChannelByName(channel).channel_id;
   if (channelId === undefined) {
     if (this.debug) util.log("Cannot leave a channel you have not joined.");
     return;
@@ -43,7 +65,6 @@ Dota2.Dota2Client.prototype.leaveChat = function(channel) {
   this._gc.send(this._protoBufHeader,
                 payload.toBuffer()
   );
-  this.chatChannels = this.chatChannels.filter(function (item) {if (item.channel_name == channel) return true; });
 };
 
 Dota2.Dota2Client.prototype.sendMessage = function(channel, message) {
@@ -100,10 +121,11 @@ handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinChatChannelResponse] = onJoinChatCh
 var onChatMessage = function onChatMessage(message) {
   /* Chat channel message from another user. */
   var chatData = Dota2.schema.CMsgDOTAChatMessage.decode(message);
-  if(this.debug) util.log("Received chat message from "+chatData.persona_name+" in "+chatData.channel_id);
+  var channel = this._getChannelById(chatData.channel_id);
+    
+  if(this.debug) util.log("Received chat message from "+chatData.persona_name+" in channel "+channel.channel_name);
   this.emit("chatMessage",
-    // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-    this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+chatData.channel_id); }).map(function (item) { return item.channel_name; })[0],
+    channel.channel_name,
     chatData.persona_name,
     chatData.text,
     chatData);
@@ -113,16 +135,16 @@ handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage] = onChatMessage;
 var onOtherJoinedChannel = function onOtherJoinedChannel(message) {
   /* Someone joined a chat channel you're in. */
   var otherJoined = Dota2.schema.CMsgDOTAOtherJoinedChatChannel.decode(message);
-  if(this.debug) util.log(otherJoined.steam_id+" joined channel "+otherJoined.channel_id);
+  var channel = this._getChannelById(otherJoined.channel_id);
+  if(this.debug) util.log(otherJoined.steam_id+" joined channel "+channel.channel_name);
   this.emit("chatJoin",
-            otherJoined.channel_id,
+            channel.channel_name,
             otherJoined.persona_name,
             otherJoined.steam_id,
             otherJoined);
   // Add member to cached chatChannels
   // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-  this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+otherJoined.channel_id); })[0]
-                    .members.push(new Dota2.schema.CMsgDOTAChatMember({
+  channel.members.push(new Dota2.schema.CMsgDOTAChatMember({
                                   steam_id: otherJoined.steam_id,
                                   persona_name: otherJoined.persona_name
                                 }));
@@ -132,15 +154,25 @@ handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCOtherJoinedChannel] = onOtherJoinedChan
 var onOtherLeftChannel = function onOtherLeftChannel(message) {
   /* Someone left a chat channel you're in. */
   var otherLeft = Dota2.schema.CMsgDOTAOtherLeftChatChannel.decode(message);
-  if(this.debug) util.log(otherLeft.steam_id+" left channel");
-  this.emit("chatLeave",
-            otherLeft.channel_id,
-            otherLeft.steam_id,
-            otherLeft);
-  // Delete member from cached chatChannel
-  // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-  var chatChannel = this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+otherLeft.channel_id); })[0];
-  chatChannel.members = chatChannel.members.filter(function (item) {return (""+item.steam_id !== ""+otherLeft.steam_id); });
+  var channel = this._getChannelById(otherLeft.channel_id);
+  // Check if it is me that left the channel
+  if (""+otherLeft.steam_id === ""+this._client.steamID) {
+    // Delete channel from cache
+    this.chatChannels = this.chatChannels.filter(function (item) {if (""+item.channel_id == ""+channel.channel_id) return false; });
+    if (this.debug) util.log("Left channel "+channel.channel_name);
+    this.emit("chatLeave",
+              channel.channel_name,
+              otherLeft.steam_id,
+              otherLeft);
+  } else {
+    if(this.debug) util.log(otherLeft.steam_id+" left channel "+channel.channel_name);
+    this.emit("chatLeave",
+              channel.channel_name,
+              otherLeft.steam_id,
+              otherLeft);
+    // Delete member from cached chatChannel
+    channel.members = channel.members.filter(function (item) {return (""+item.steam_id !== ""+otherLeft.steam_id); });
+  }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCOtherLeftChannel] = onOtherLeftChannel;
 

--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -143,7 +143,6 @@ var onOtherJoinedChannel = function onOtherJoinedChannel(message) {
             otherJoined.steam_id,
             otherJoined);
   // Add member to cached chatChannels
-  // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
   channel.members.push(new Dota2.schema.CMsgDOTAChatMember({
                                   steam_id: otherJoined.steam_id,
                                   persona_name: otherJoined.persona_name

--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -3,7 +3,7 @@ var Dota2 = require("../index"),
 
 // Methods
 Dota2.Dota2Client.prototype._getChannelByName = function(channel_name) {
-  // Returns the channel_name correspondig to the given channel_id
+  // Returns the channel corresponding to the given channel_name
   if (this.chatChannels) {
     return this.chatChannels.filter(
         function (item) { return (item.channel_name === channel_name); }
@@ -14,7 +14,7 @@ Dota2.Dota2Client.prototype._getChannelByName = function(channel_name) {
 }
 
 Dota2.Dota2Client.prototype._getChannelById = function(channel_id) {
-  // Returns the channel_name correspondig to the given channel_id
+  // Returns the channel corresponding to the given channel_id
   if (this.chatChannels) {
     return this.chatChannels.filter(
         // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String


### PR DESCRIPTION
Fixed a bug with the cache where instead of deleting the channel you leave it deletes all channels but the one you left.
I also changed the event for `chatJoin` and `chatLeave` to return the `channel_name` instead of the `channel_id`. This is consistent with the other events and methods, where the user of the API always passes a `channel_name`.
Finally I also switched the location where the cache is cleaned up. Previously, the channel was removed from cache upon sending the `leaveChat` message. The GC however always sends a confirmation of you leaving by sending you a final `CMsgDOTAOtherLeftChatChannel` message with your own `steamID`. It makes more sense in my opinion to remove the channel from cache only when this confirmation is received.

I tested all chat functionality I touched, everything seems to still be working.