### PR TITLE
Change chat API to only expose channel names to user

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,41 +7,11 @@ Check out my blog post (my only blog post), [Extending node-dota2](https://blog.
 
 ## Upgrade guide
 
-### `<= 0.7.*` to `1.0.0`
+### `1.*.*` to `2.0.0`
 
-A few backwards incompatible API changes were included with version 1.0.0.
+A few backwards incompatible API changes were included with version 2.0.0.
 
-The following methods were renamed:
-
-Old method name                | New method name
-----                           | ----
-getPlayerMatchHistory          | requestPlayerMatchHistory
-profileRequest                 | requestProfile
-passportDataRequest            | requestPassportData
-hallOfFameRequest              | requestHallOfFame
-leaguesInMonthRequest          | requestLeaguesInMonth
-practiceLobbyListRequest       | requestPracticeLobbyList
-friendPracticeLobbyListRequest | requestFriendPracticeLobbyList
-matchDetailsRequest            | requestMatchDetails
-matchmakingStatsRequest        | requestMatchmakingStats
-findSourceTVGames              | requestSourceTVGames
-
-And the following events were renamed:
-
-Old event name                  | New event name
-----                            | ----
-chatChannelsReceived            | chatChannelsData
-guildInvite                     | guildInviteData
-leaguesInMonthResponse          | leaguesInMonthData
-leagueInfo                      | leagueData
-practiceLobbyListResponse       | practiceLobbyListData
-friendPracticeLobbyListResponse | friendPracticeLobbyListData
-matches                         | matchesData
-matchData                       | matchDetailsData
-
-Finally we migrated to the 1.x.y version of node-steam. This caused all proto 
-messages to become snake_cased instead of camelCased. As a consequence, many 
-tags in responses and events have changed.
+* The `chatJoin` and `chatLeave` events were changed to return the channel name instead of the id. All debug logs pertaining chat channels will now mention chat channel instead of IDs.
 
 ## Initializing
 Parameters:
@@ -405,16 +375,16 @@ Emitted when the connection status to the GC changes, and renders the library un
 
 Emitted for chat messages received from Dota 2 chat channels
 
-### `chatJoin` (`channel_id`, `joiner_name`, `joiner_steam_id`, `otherJoined_object`)
-* `channel_id`
+### `chatJoin` (`channel`, `joiner_name`, `joiner_steam_id`, `otherJoined_object`)
+* `channel` - Channel name.
 * `joiner_name` - Persona name of user who joined.
 * `joiner_steam_id` - Steam ID of the user who joined.
 * `otherJoined_object` - The raw `CMsgDOTAOtherJoinedChatChannel` object for you to do with as you wish.
 
 Emitted when another user joins a chat channel you are in.
 
-### `chatLeave` (`channel_id`, `leaver_steam_id`, `otherLeft_object`)
-* `channel_id`
+### `chatLeave` (`channel`, `leaver_steam_id`, `otherLeft_object`)
+* `channel` - Channel name.
 * `leaver_steam_id` - Steam ID of the user who left.
 * `otherLeft_object` - The raw `CMsgDOTAOtherLeftChatChannel` object for you to do with as you wish.
 

--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -2,6 +2,28 @@ var Dota2 = require("../index"),
     util = require("util");
 
 // Methods
+Dota2.Dota2Client.prototype._getChannelByName = function(channel_name) {
+  // Returns the channel corresponding to the given channel_name
+  if (this.chatChannels) {
+    return this.chatChannels.filter(
+        function (item) { return (item.channel_name === channel_name); }
+      )[0];
+  } else {
+    return null;
+  }
+}
+
+Dota2.Dota2Client.prototype._getChannelById = function(channel_id) {
+  // Returns the channel corresponding to the given channel_id
+  if (this.chatChannels) {
+    return this.chatChannels.filter(
+        // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
+        function (item) { return (""+item.channel_id === ""+channel_id); }
+      )[0];
+  } else {
+    return null;
+  }
+}
 
 Dota2.Dota2Client.prototype.joinChat = function(channel, type) {
   type = type || Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom;
@@ -31,7 +53,7 @@ Dota2.Dota2Client.prototype.leaveChat = function(channel) {
   }
 
   if (this.debug) util.log("Leaving chat channel: " + channel);
-  var channelId = this.chatChannels.filter(function (item) {return (item.channel_name == channel); }).map(function (item) { return item.channel_id; })[0]
+  var channelId = this._getChannelByName(channel).channel_id;
   if (channelId === undefined) {
     if (this.debug) util.log("Cannot leave a channel you have not joined.");
     return;
@@ -43,7 +65,6 @@ Dota2.Dota2Client.prototype.leaveChat = function(channel) {
   this._gc.send(this._protoBufHeader,
                 payload.toBuffer()
   );
-  this.chatChannels = this.chatChannels.filter(function (item) {if (item.channel_name == channel) return false; });
 };
 
 Dota2.Dota2Client.prototype.sendMessage = function(channel, message) {
@@ -100,10 +121,11 @@ handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinChatChannelResponse] = onJoinChatCh
 var onChatMessage = function onChatMessage(message) {
   /* Chat channel message from another user. */
   var chatData = Dota2.schema.CMsgDOTAChatMessage.decode(message);
-  if(this.debug) util.log("Received chat message from "+chatData.persona_name+" in "+chatData.channel_id);
+  var channel = this._getChannelById(chatData.channel_id);
+    
+  if(this.debug) util.log("Received chat message from "+chatData.persona_name+" in channel "+channel.channel_name);
   this.emit("chatMessage",
-    // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-    this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+chatData.channel_id); }).map(function (item) { return item.channel_name; })[0],
+    channel.channel_name,
     chatData.persona_name,
     chatData.text,
     chatData);
@@ -113,16 +135,15 @@ handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage] = onChatMessage;
 var onOtherJoinedChannel = function onOtherJoinedChannel(message) {
   /* Someone joined a chat channel you're in. */
   var otherJoined = Dota2.schema.CMsgDOTAOtherJoinedChatChannel.decode(message);
-  if(this.debug) util.log(otherJoined.steam_id+" joined channel "+otherJoined.channel_id);
+  var channel = this._getChannelById(otherJoined.channel_id);
+  if(this.debug) util.log(otherJoined.steam_id+" joined channel "+channel.channel_name);
   this.emit("chatJoin",
-            otherJoined.channel_id,
+            channel.channel_name,
             otherJoined.persona_name,
             otherJoined.steam_id,
             otherJoined);
   // Add member to cached chatChannels
-  // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-  this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+otherJoined.channel_id); })[0]
-                    .members.push(new Dota2.schema.CMsgDOTAChatMember({
+  channel.members.push(new Dota2.schema.CMsgDOTAChatMember({
                                   steam_id: otherJoined.steam_id,
                                   persona_name: otherJoined.persona_name
                                 }));
@@ -132,15 +153,25 @@ handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCOtherJoinedChannel] = onOtherJoinedChan
 var onOtherLeftChannel = function onOtherLeftChannel(message) {
   /* Someone left a chat channel you're in. */
   var otherLeft = Dota2.schema.CMsgDOTAOtherLeftChatChannel.decode(message);
-  if(this.debug) util.log(otherLeft.steam_id+" left channel");
-  this.emit("chatLeave",
-            otherLeft.channel_id,
-            otherLeft.steam_id,
-            otherLeft);
-  // Delete member from cached chatChannel
-  // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-  var chatChannel = this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+otherLeft.channel_id); })[0];
-  chatChannel.members = chatChannel.members.filter(function (item) {return (""+item.steam_id !== ""+otherLeft.steam_id); });
+  var channel = this._getChannelById(otherLeft.channel_id);
+  // Check if it is me that left the channel
+  if (""+otherLeft.steam_id === ""+this._client.steamID) {
+    if (this.debug) util.log("Left channel "+channel.channel_name);
+    this.emit("chatLeave",
+              channel.channel_name,
+              otherLeft.steam_id,
+              otherLeft);
+    // Delete channel from cache
+    this.chatChannels = this.chatChannels.filter(function (item) {if (""+item.channel_id == ""+channel.channel_id) return false; });
+  } else {
+    if(this.debug) util.log(otherLeft.steam_id+" left channel "+channel.channel_name);
+    this.emit("chatLeave",
+              channel.channel_name,
+              otherLeft.steam_id,
+              otherLeft);
+    // Delete member from cached chatChannel
+    channel.members = channel.members.filter(function (item) {return (""+item.steam_id !== ""+otherLeft.steam_id); });
+  }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCOtherLeftChannel] = onOtherLeftChannel;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dota2",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "dependencies": {
     "bignumber.js": "2.0.7",
     "deferred": "^0.7.2",


### PR DESCRIPTION
First commit for v2.0.0. I made the chat.js handler more uniform so we only expose channel names. The user of the API is only concerned with channel names, it's what is given when creating them and how the user interacts with them when sending/receiving messages. Up until now in certain cases the user would receive join/leave events with the channel IDs as well as certain debug logs also containing IDs. This can be confusing for users (me xD) the first time they interact with the chat API.

For the two helper functions, I gave them _ names because I didn't know if they needed to be exposed or not. If someone thinks it useful, we might make the `getChannelByName` function public.