### PR TITLE
Added requestTeamIDByName function

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,12 @@ Requests the authenticated user's team data.
 
 Requests the profile for a given team.
 
+#### requestTeamIDByName(team_name, [callback])
+* `team_name` - Name of a team
+* `[callback]` - optional callback, returns args: `err, response`.
+
+Requests the ID for a given team name.
+
 ### Community
 #### requestPlayerMatchHistory(account_id, [options], [callback])
 * `account_id` - Account ID of the user whose match history you wish to retrieve.
@@ -457,7 +463,6 @@ Emitted when GC responds to the `requestMyTeams` method.
 
 See the [protobuf schema](https://github.com/SteamRE/SteamKit/blob/master/Resources/Protobufs/dota/dota_gcmessages_client.proto#L776) for `team`'s object structure.
 
-
 ### `teamProfile` (`team_id`, `team_info`)
 * `team_id` - ID of the team.
 * `team_info` - Info about the team. This contains among others:
@@ -472,6 +477,11 @@ See the [protobuf schema](https://github.com/SteamRE/SteamKit/blob/master/Resour
 Emitted when GC responds to the `requestTeamProfile` method.
 
 See the [protobuf schema](https://github.com/SteamRE/SteamKit/blob/master/Resources/Protobufs/dota/dota_gcmessages_client.proto#L776) for `team_info`'s object structure.
+
+### `teamID` (`team_id`)
+* `team_id` - ID of the team. Null if none was found.
+
+Emitted when GC responds to the `requestTeamIDByName` method.
 
 ### `profileData` (`account_id`, `profileData`)
 * `account_id` - Account ID whom the data is associated with.


### PR DESCRIPTION
It's now possible to obtain a team ID when given the team name. I deviated slightly from our usual treatment of responses in emitting an event in the case of a bad response. The GC returns a fail message when it doesn't  find a team matching the name you specified. I felt that it would be better in this case to emit an event with an empty team ID to indicate nothing was found instead of just never responding.