### PR TITLE
Changed/updated matchmakingStatsData

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,8 @@ A few backwards incompatible API changes were included with version 2.0.0.
 
 * The `chatJoin` and `chatLeave` events were changed to return the channel name instead of the id. All debug logs pertaining chat channels will now mention chat channel instead of IDs.
 
+* The `disabledGroups` argument in the `matchmakingStatsData` event has been removed.
+
 ## Initializing
 Parameters:
 * `steamClient` - Pass a SteamClient instance to use to send & receive GC messages.
@@ -599,10 +601,9 @@ Emitted when GC responds to the `requestmatchDetails` method.
 
 See the [protobuf schema](https://github.com/SteamRE/SteamKit/blob/master/Resources/Protobufs/dota/dota_gcmessages_client.proto#L1571) for `matchDetailsData`'s object structure.
 
-### `matchmakingStatsData` (`waitTimesByGroup`, `searchingPlayersByGroup`, `disabledGroups`, `matchmakingStatsResponse`)
-* `waitTimesByGroup` - Current average matchmaking waiting times, in seconds, per group.
+### `matchmakingStatsData` (`searchingPlayersByGroup`, `disabledGroups`, `matchmakingStatsResponse`)
 * `searchingPlayersByGroup` - Current players searching for matches per group.
-* `disabledGroups` - I don't know how the data is formatted here, I've only observed it to be zero.
+* `disabledGroups` - 16bit bitmask corresponding to groups in `searchingPlayersByGroup`. These values will be 0.
 * `matchmakingStatsResponse` - Raw response object.
 
 Emitted when te GC response to the `requestMatchmakingStats` method.  The array order dictates which matchmaking groups the figure belongs to. 
@@ -611,19 +612,26 @@ This list is manually updated only when changes are detected by community member
 Here are the groups at the time of this sentence being written (with unecessary data trimmed out):
 
 ```
-    "USWest":               {"matchgroup": "0"},
-    "USEast":               {"matchgroup": "1"},
-    "Europe":               {"matchgroup": "2"},
-    "Singapore":            {"matchgroup": "3"},
-    "Shanghai":             {"matchgroup": "4"},
-    "Brazil":               {"matchgroup": "5"},
-    "Korea":                {"matchgroup": "6"},
-    "Austria":              {"matchgroup": "8"},
-    "Stockholm":            {"matchgroup": "7"},
-    "Australia":            {"matchgroup": "9"},
-    "SouthAfrica":          {"matchgroup": "10"},
-    "PerfectWorldTelecom":  {"matchgroup": "11"},
-    "PerfectWorldUnicom":   {"matchgroup": "12"}
+    "USWest":                       {"matchgroup": "0"},
+    "USEast":                       {"matchgroup": "1"},
+    "Europe":                       {"matchgroup": "2"},
+    "Singapore":                    {"matchgroup": "3"},
+    "Shanghai":                     {"matchgroup": "4"},
+    "Brazil":                       {"matchgroup": "5"},
+    "Korea":                        {"matchgroup": "6"},
+    "Austria":                      {"matchgroup": "8"},
+    "Stockholm":                    {"matchgroup": "7"},
+    "Australia":                    {"matchgroup": "9"},
+    "SouthAfrica":                  {"matchgroup": "10"},
+    "PerfectWorldTelecom":          {"matchgroup": "11"},
+    "PerfectWorldUnicom":           {"matchgroup": "12"},
+    "Dubai":                        {"matchgroup": "13"},
+    "Chile":                        {"matchgroup": "14"},
+    "Peru":                         {"matchgroup": "15"},
+    "India":                        {"matchgroup": "16"},
+    "PerfectWorldTelecomGuangdong": {"matchgroup": "17"},
+    "PerfectWorldTelecomZhejiang":  {"matchgroup": "18"},
+    "Japan":                        {"matchgroup": "19"}
 ```
 
 ### `practiceLobbyUpdate` (`lobby`)

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ See the [protobuf schema](https://github.com/SteamRE/SteamKit/blob/master/Resour
 
 ### `matchmakingStatsData` (`searchingPlayersByGroup`, `disabledGroups`, `matchmakingStatsResponse`)
 * `searchingPlayersByGroup` - Current players searching for matches per group.
-* `disabledGroups` - Bitmask corresponding to groups in `searchingPlayersByGroup`. These values will be 0.
+* `disabledGroups` - Bitmask corresponding to groups in `searchingPlayersByGroup`. Groups marked as disabled will have a value of 0.
 * `matchmakingStatsResponse` - Raw response object.
 
 Emitted when te GC response to the `requestMatchmakingStats` method.  The array order dictates which matchmaking groups the figure belongs to. 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ A few backwards incompatible API changes were included with version 2.0.0.
 
 * The `chatJoin` and `chatLeave` events were changed to return the channel name instead of the id. All debug logs pertaining chat channels will now mention chat channel instead of IDs.
 
-* The `disabledGroups` argument in the `matchmakingStatsData` event has been removed.
+* The `waitTimesByGroup` argument in the `matchmakingStatsData` event has been removed.
 
 ## Initializing
 Parameters:
@@ -619,8 +619,8 @@ Here are the groups at the time of this sentence being written (with unecessary 
     "Shanghai":                     {"matchgroup": "4"},
     "Brazil":                       {"matchgroup": "5"},
     "Korea":                        {"matchgroup": "6"},
-    "Austria":                      {"matchgroup": "8"},
     "Stockholm":                    {"matchgroup": "7"},
+    "Austria":                      {"matchgroup": "8"},
     "Australia":                    {"matchgroup": "9"},
     "SouthAfrica":                  {"matchgroup": "10"},
     "PerfectWorldTelecom":          {"matchgroup": "11"},

--- a/README.md
+++ b/README.md
@@ -603,7 +603,7 @@ See the [protobuf schema](https://github.com/SteamRE/SteamKit/blob/master/Resour
 
 ### `matchmakingStatsData` (`searchingPlayersByGroup`, `disabledGroups`, `matchmakingStatsResponse`)
 * `searchingPlayersByGroup` - Current players searching for matches per group.
-* `disabledGroups` - 16bit bitmask corresponding to groups in `searchingPlayersByGroup`. These values will be 0.
+* `disabledGroups` - Bitmask corresponding to groups in `searchingPlayersByGroup`. These values will be 0.
 * `matchmakingStatsResponse` - Raw response object.
 
 Emitted when te GC response to the `requestMatchmakingStats` method.  The array order dictates which matchmaking groups the figure belongs to. 

--- a/handlers/match.js
+++ b/handlers/match.js
@@ -157,9 +157,8 @@ var onMatchmakingStatsResponse = function onMatchmakingStatsResponse(message) {
 
     if (this.debug) util.log("Received matchmaking stats");
     this.emit("matchmakingStatsData",
-        matchmakingStatsResponse.wait_times_by_group,
-        matchmakingStatsResponse.searching_players_by_group,
-        matchmakingStatsResponse.disabled_groups,
+        matchmakingStatsResponse.searching_players_by_group_source2,
+        matchmakingStatsResponse.disabled_groups_source2,
         matchmakingStatsResponse);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCMatchmakingStatsResponse] = onMatchmakingStatsResponse;


### PR DESCRIPTION
Redoing my previous PR because I'm incompetent.  As for the bitmask issue, I think @Crazy-Duck is correct, but it's probably not 16 bit since there are 20 entries, so perhaps 32 bit. 

![nethook dump](http://i.imgur.com/cROQaxE.png)

If the values are matched as so:
```
0: 1,
1: 2,
2: 4,
3: 8,
4: 16,
5: 32,
6: 64,
7: 128,
8: 256,
9: 512,
10: 1024,
11: 2048,
12: 4096,
13: 8192,
14: 16384,
15: 32768,
16: 65536,
17: 131072,
18: 262144,
19: 524288
```
16 + 65536 = 65552, which matches `disabled_groups_source2`.