### PR TITLE
v2.0.0

### DIFF
--- a/handlers/cache.js
+++ b/handlers/cache.js
@@ -2,126 +2,134 @@ var Dota2 = require("../index"),
     util = require("util");
 
 var cacheTypeIDs = {
-  LOBBY: 2004,
-  PARTY: 2003,
-  PARTY_INVITE: 2006
+    LOBBY: 2004,
+    PARTY: 2003,
+    PARTY_INVITE: 2006,
+    LOBBY_INVITE: 2011
 };
 
 // Handlers
-function handleSubscribedType(obj_type, object_data)
-{
-  switch(obj_type)
-  {
-    // Lobby snapshot.
-    case cacheTypeIDs.LOBBY:
-      var lobby = Dota2.schema.CSODOTALobby.decode(object_data);
-      if(this.debug) util.log("Received lobby snapshot for lobby ID "+lobby.lobby_id);
-      this.emit("practiceLobbyUpdate", lobby);
-      this.Lobby = lobby;
-      break;
-    // Party snapshot.
-    case cacheTypeIDs.PARTY:
-      var party = Dota2.schema.CSODOTAParty.decode(object_data);
-      if(this.debug) util.log("Received party snapshot for party ID "+party.party_id);
-      this.emit("partyUpdate", party);
-      this.Party = party;
-      break;
-    // Party invite snapshot.
-    case cacheTypeIDs.PARTY_INVITE:
-      var party = Dota2.schema.CSODOTAPartyInvite.decode(object_data);
-      if(this.debug) util.log("Received party invite snapshot for group ID "+party.group_id);
-      this.emit("partyInviteUpdate", party);
-      this.PartyInvite = party;
-      break;
-    default:
-      if(this.debug) util.log("Unknown cache ID: "+obj_type);
-      break;
-  }
+function handleSubscribedType(obj_type, object_data) {
+    switch (obj_type) {
+        // Lobby snapshot.
+        case cacheTypeIDs.LOBBY:
+            var lobby = Dota2.schema.CSODOTALobby.decode(object_data);
+            if (this.debug) util.log("Received lobby snapshot for lobby ID " + lobby.lobby_id);
+            this.emit("practiceLobbyUpdate", lobby);
+            this.Lobby = lobby;
+            break;
+        // Lobby invite snapshot.
+        case cacheTypeIDs.LOBBY_INVITE:
+            var lobby = Dota2.schema.CSODOTALobbyInvite.decode(object_data);
+            if (this.debug) util.log("Received lobby invite snapshot for group ID " + lobby.group_id);
+            this.emit("lobbyInviteUpdate", lobby);
+            this.LobbyInvite = lobby;
+            break;
+        // Party snapshot.
+        case cacheTypeIDs.PARTY:
+            var party = Dota2.schema.CSODOTAParty.decode(object_data);
+            if (this.debug) util.log("Received party snapshot for party ID " + party.party_id);
+            this.emit("partyUpdate", party);
+            this.Party = party;
+            break;
+        // Party invite snapshot.
+        case cacheTypeIDs.PARTY_INVITE:
+            var party = Dota2.schema.CSODOTAPartyInvite.decode(object_data);
+            if (this.debug) util.log("Received party invite snapshot for group ID " + party.group_id);
+            this.emit("partyInviteUpdate", party);
+            this.PartyInvite = party;
+            break;
+        default:
+            if (this.debug) util.log("Unknown cache ID: " + obj_type);
+            break;
+    }
 };
 
-Dota2.Dota2Client.prototype._handleWelcomeCaches = function handleWelcomeCaches(message)
-{
-  var welcome = Dota2.schema.CMsgClientWelcome.decode(message);
-  var _self = this;
+Dota2.Dota2Client.prototype._handleWelcomeCaches = function handleWelcomeCaches(message) {
+    var welcome = Dota2.schema.CMsgClientWelcome.decode(message);
+    var _self = this;
 
-  if(welcome.outofdate_subscribed_caches)
-    welcome.outofdate_subscribed_caches.forEach(function(cache){
-      cache.objects.forEach(function(obj){
-        handleSubscribedType.call(_self, obj.type_id, obj.object_data[0]);
-      });
-    });
+    if (welcome.outofdate_subscribed_caches)
+        welcome.outofdate_subscribed_caches.forEach(function(cache) {
+            cache.objects.forEach(function(obj) {
+                handleSubscribedType.call(_self, obj.type_id, obj.object_data[0]);
+            });
+        });
 };
 
 var handlers = Dota2.Dota2Client.prototype._handlers;
 
 var onCacheSubscribed = function onCacheSubscribed(message) {
-  var subscribe = Dota2.schema.CMsgSOCacheSubscribed.decode(message);
-  var _self = this;
+    var subscribe = Dota2.schema.CMsgSOCacheSubscribed.decode(message);
+    var _self = this;
 
-  if(this.debug){
-    util.log("Cache subscribed, type "+subscribe.objects[0].type_id);
-  }
+    if (this.debug) {
+        util.log("Cache subscribed, type " + subscribe.objects[0].type_id);
+    }
 
-  subscribe.objects.forEach(function(obj){
-    handleSubscribedType.call(_self, obj.type_id, obj.object_data[0]);
-  });
+    subscribe.objects.forEach(function(obj) {
+        handleSubscribedType.call(_self, obj.type_id, obj.object_data[0]);
+    });
 };
 handlers[Dota2.schema.ESOMsg.k_ESOMsg_CacheSubscribed] = onCacheSubscribed;
 
 var onUpdateMultiple = function onUpdateMultiple(message) {
-  var multi = Dota2.schema.CMsgSOMultipleObjects.decode(message);
-  var _self = this;
+    var multi = Dota2.schema.CMsgSOMultipleObjects.decode(message);
+    var _self = this;
 
-  if(multi.objects_modified)
-    multi.objects_modified.forEach(function(obj){
-      handleSubscribedType.call(_self, obj.type_id, obj.object_data);
-    });
+    if (multi.objects_modified)
+        multi.objects_modified.forEach(function(obj) {
+            handleSubscribedType.call(_self, obj.type_id, obj.object_data);
+        });
 };
 handlers[Dota2.schema.ESOMsg.k_ESOMsg_UpdateMultiple] = onUpdateMultiple;
 
 var onCreate = function onCreate(message) {
-  var single = Dota2.schema.CMsgSOSingleObject.decode(message);
-  var _self = this;
+    var single = Dota2.schema.CMsgSOSingleObject.decode(message);
+    var _self = this;
 
-  if(this.debug){
-    util.log("Create, type "+single.type_id);
-  }
-  handleSubscribedType.call(_self, single.type_id, single.object_data);
+    if (this.debug) {
+        util.log("Create, type " + single.type_id);
+    }
+    handleSubscribedType.call(_self, single.type_id, single.object_data);
 }
 handlers[Dota2.schema.ESOMsg.k_ESOMsg_Create] = onCreate;
 
 var onCacheUnsubscribed = function onCacheUnsubscribed(message) {
-  var unsubscribe = Dota2.schema.CMsgSOCacheUnsubscribed.decode(message);
-  var _self = this;
+    var unsubscribe = Dota2.schema.CMsgSOCacheUnsubscribed.decode(message);
+    var _self = this;
 
-  if(this.debug) util.log("Cache unsubscribed, "+unsubscribe.owner_soid.id);
+    if (this.debug) util.log("Cache unsubscribed, " + unsubscribe.owner_soid.id);
 
-  if(this.Lobby && ""+unsubscribe.owner_soid.id === ""+this.Lobby.lobby_id)
-  {
-    this.Lobby = null;
-    this.emit("practiceLobbyCleared");
-  }else if(this.Party && ""+unsubscribe.owner_soid.id === ""+this.Party.party_id)
-  {
-    this.Party = null;
-    this.emit("partyCleared");
-  }else if(this.PartyInvite && ""+unsubscribe.owner_soid.id === ""+this.PartyInvite.group_id)
-  {
-    this.PartyInvite = null;
-    this.emit("partyInviteCleared");
-  }
+    if (this.Lobby && "" + unsubscribe.owner_soid.id === "" + this.Lobby.lobby_id) {
+        this.Lobby = null;
+        this.emit("practiceLobbyCleared");
+    } else if (this.LobbyInvite && "" + unsubscribe.owner_soid.id === "" + this.LobbyInvite.group_id) {
+        this.LobbyInvite = null;
+        this.emit("lobbyInviteCleared");
+    } else if (this.Party && "" + unsubscribe.owner_soid.id === "" + this.Party.party_id) {
+        this.Party = null;
+        this.emit("partyCleared");
+    } else if (this.PartyInvite && "" + unsubscribe.owner_soid.id === "" + this.PartyInvite.group_id) {
+        this.PartyInvite = null;
+        this.emit("partyInviteCleared");
+    }
 };
 handlers[Dota2.schema.ESOMsg.k_ESOMsg_CacheUnsubscribed] = onCacheUnsubscribed;
 
 var onCacheDestroy = function onCacheDestroy(message) {
-  var destroy = Dota2.schema.CMsgSOSingleObject.decode(message);
-  var _self = this;
+    var destroy = Dota2.schema.CMsgSOSingleObject.decode(message);
+    var _self = this;
 
-  if(this.debug) util.log("Cache destroy, "+destroy.type_id);
+    if (this.debug) util.log("Cache destroy, " + destroy.type_id);
 
-  if(destroy.type_id === cacheTypeIDs.PARTY_INVITE)
-  {
-    this.PartyInvite = null;
-    this.emit("partyInviteCleared");
-  }
+    if (destroy.type_id === cacheTypeIDs.PARTY_INVITE) {
+        this.PartyInvite = null;
+        this.emit("partyInviteCleared");
+    }
+    if (destroy.type_id === cacheTypeIDs.LOBBY_INVITE) {
+        this.LobbyInvite = null;
+        this.emit("lobbyInviteCleared");
+    }
 };
-handlers[Dota2.schema.ESOMsg.k_ESOMsg_CacheDestroy] = onCacheDestroy;
+handlers[Dota2.schema.ESOMsg.k_ESOMsg_Destroy] = onCacheDestroy;

--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -2,87 +2,144 @@ var Dota2 = require("../index"),
     util = require("util");
 
 // Methods
+Dota2.Dota2Client.prototype._getChannelByName = function(channel_name) {
+    // Returns the channel corresponding to the given channel_name
+    if (this.chatChannels) {
+        return this.chatChannels.filter(
+            function(item) {
+                return (item.channel_name === channel_name);
+            }
+        )[0];
+    } else {
+        return null;
+    }
+}
+
+Dota2.Dota2Client.prototype._getChannelById = function(channel_id) {
+    // Returns the channel corresponding to the given channel_id
+    if (this.chatChannels) {
+        return this.chatChannels.filter(
+            // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
+            function(item) {
+                return ("" + item.channel_id === "" + channel_id);
+            }
+        )[0];
+    } else {
+        return null;
+    }
+}
 
 Dota2.Dota2Client.prototype.joinChat = function(channel, type) {
-  type = type || Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom;
+    type = type || Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom;
 
-  /* Attempts to join a chat channel.  Expect k_EMsgGCJoinChatChannelResponse from GC */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Joining chat channel: " + channel);
-  var payload = new Dota2.schema.CMsgDOTAJoinChatChannel({
-    "channel_name": channel,
-    "channel_type": type
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinChatChannel;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    /* Attempts to join a chat channel.  Expect k_EMsgGCJoinChatChannelResponse from GC */
+    if (this.debug) util.log("Joining chat channel: " + channel);
+    
+    var payload = new Dota2.schema.CMsgDOTAJoinChatChannel({
+        "channel_name": channel,
+        "channel_type": type
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinChatChannel, payload);
 };
 
 Dota2.Dota2Client.prototype.leaveChat = function(channel) {
-  /* Attempts to leave a chat channel. GC does not send a response. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Leaving chat channel: " + channel);
-  var channelId = this.chatChannels.filter(function (item) {return (item.channel_name == channel); }).map(function (item) { return item.channel_id; })[0]
-  if (channelId === undefined) {
-    if (this.debug) util.log("Cannot leave a channel you have not joined.");
-    return;
-  }
-  var payload = new Dota2.schema.CMsgDOTALeaveChatChannel({
-    "channel_id": channelId
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCLeaveChatChannel;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
-  this.chatChannels = this.chatChannels.filter(function (item) {if (item.channel_name == channel) return false; });
+    /* Attempts to leave a chat channel. GC does not send a response. */
+    if (this.debug) util.log("Leaving chat channel: " + channel);
+    // Clear cache
+    var cache = this._getChannelByName(channel);
+    if (cache === undefined) {
+        if (this.debug) util.log("Cannot leave a channel you have not joined.");
+        return;
+    }
+    
+    var payload = new Dota2.schema.CMsgDOTALeaveChatChannel({
+        "channel_id": cache.channel_id
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCLeaveChatChannel, payload);
 };
 
 Dota2.Dota2Client.prototype.sendMessage = function(channel, message) {
-  /* Attempts to send a message to a chat channel. GC does not send a response. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    /* Attempts to send a message to a chat channel. GC does not send a response. */
+    if (this.debug) util.log("Sending message to " + channel);
+    // Check cache
+    var cache = this._getChannelByName(channel);
+    if (cache === undefined) {
+        if (this.debug) util.log("Cannot send message to a channel you have not joined.");
+        return;
+    }
+    
+    var payload = new Dota2.schema.CMsgDOTAChatMessage({
+        "channel_id": cache.channel_id,
+        "text": message
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage, payload);
+};
 
-  if (this.debug) util.log("Sending message to " + channel);
-  var channelId = this.chatChannels.filter(function (item) {return (item.channel_name == channel);}).map(function (item) { return item.channel_id; })[0]
-  if (channelId === undefined) {
-    if (this.debug) util.log("Cannot send message to a channel you have not joined.");
-    return;
-  }
-  var payload = new Dota2.schema.CMsgDOTAChatMessage({
-    "channel_id": channelId,
-    "text": message
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+Dota2.Dota2Client.prototype.shareLobby = function(channel) {
+    /* Attempts to send a message to a chat channel. GC does not send a response. */
+    if (this.debug) util.log("Sharing lobby to " + channel);
+    // Check cache
+    var cache = this._getChannelByName(channel);
+    if (cache === undefined) {
+        if (this.debug) util.log("Cannot send message to a channel you have not joined.");
+        return;
+    }
+    if (this.Lobby === undefined) {
+        if (this.debug) util.log("Cannot share a lobby when you're not in one.");
+        return;
+    }
+    
+    var payload = new Dota2.schema.CMsgDOTAChatMessage({
+        "channel_id": cache.channel_id,
+        "share_lobby_id": this.Lobby.lobby_id,
+        "share_lobby_passkey": this.Lobby.pass_key
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage, payload);
+};
+
+Dota2.Dota2Client.prototype.flipCoin = function(channel) {
+    /* Attempts to send a coin flip to a chat channel. Expect a chatmessage in response. */
+    if (this.debug) util.log("Sending coin flip to " + channel);
+    // Check cache
+    var cache = this._getChannelByName(channel);
+    if (cache === undefined) {
+        if (this.debug) util.log("Cannot send message to a channel you have not joined.");
+        return;
+    }
+    
+    var payload = new Dota2.schema.CMsgDOTAChatMessage({
+        "channel_id": cache.channel_id,
+        "coin_flip": true
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage, payload);
+};
+
+Dota2.Dota2Client.prototype.rollDice = function(channel, min, max) {
+    /* Attempts to send a dice roll to a chat channel. Expect a chatmessage in response. */
+    if (this.debug) util.log("Sending dice roll to " + channel);
+    // Check cache
+    var cache = this._getChannelByName(channel);
+    if (cache === undefined) {
+        if (this.debug) util.log("Cannot send message to a channel you have not joined.");
+        return;
+    }
+    
+    var payload = new Dota2.schema.CMsgDOTAChatMessage({
+        "channel_id": cache.channel_id,
+        "dice_roll": {
+            "roll_min": min,
+            "roll_max": max
+        }
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage, payload);
 };
 
 Dota2.Dota2Client.prototype.requestChatChannels = function() {
-  /* Requests a list of chat channels from the GC. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Requesting channel list");
-  var payload = new Dota2.schema.CMsgDOTARequestChatChannelList({
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestChatChannelList;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    /* Requests a list of chat channels from the GC. */
+    if (this.debug) util.log("Requesting channel list");
+    
+    var payload = new Dota2.schema.CMsgDOTARequestChatChannelList({});
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestChatChannelList, payload);
 };
 
 // Handlers
@@ -90,62 +147,76 @@ Dota2.Dota2Client.prototype.requestChatChannels = function() {
 var handlers = Dota2.Dota2Client.prototype._handlers;
 
 var onJoinChatChannelResponse = function onJoinChatChannelResponse(message) {
-  /* Channel data after we sent k_EMsgGCJoinChatChannel */
-  var channelData = Dota2.schema.CMsgDOTAJoinChatChannelResponse.decode(message);
-  if (this.debug) util.log("Chat channel "+channelData.channel_name+ " has "+channelData.members.length+" person(s) online");
-  this.chatChannels.push(channelData);
+    /* Channel data after we sent k_EMsgGCJoinChatChannel */
+    var channelData = Dota2.schema.CMsgDOTAJoinChatChannelResponse.decode(message);
+    if (this.debug) util.log("Chat channel " + channelData.channel_name + " has " + channelData.members.length + " person(s) online");
+    this.chatChannels.push(channelData);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinChatChannelResponse] = onJoinChatChannelResponse;
 
 var onChatMessage = function onChatMessage(message) {
-  /* Chat channel message from another user. */
-  var chatData = Dota2.schema.CMsgDOTAChatMessage.decode(message);
-  if(this.debug) util.log("Received chat message from "+chatData.persona_name+" in "+chatData.channel_id);
-  this.emit("chatMessage",
-    // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-    this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+chatData.channel_id); }).map(function (item) { return item.channel_name; })[0],
-    chatData.persona_name,
-    chatData.text,
-    chatData);
+    /* Chat channel message from another user. */
+    var chatData = Dota2.schema.CMsgDOTAChatMessage.decode(message);
+    var channel = this._getChannelById(chatData.channel_id);
+
+    if (this.debug) util.log("Received chat message from " + chatData.persona_name + " in channel " + channel.channel_name);
+    this.emit("chatMessage",
+        channel.channel_name,
+        chatData.persona_name,
+        chatData.text,
+        chatData);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage] = onChatMessage;
 
 var onOtherJoinedChannel = function onOtherJoinedChannel(message) {
-  /* Someone joined a chat channel you're in. */
-  var otherJoined = Dota2.schema.CMsgDOTAOtherJoinedChatChannel.decode(message);
-  if(this.debug) util.log(otherJoined.steam_id+" joined channel "+otherJoined.channel_id);
-  this.emit("chatJoin",
-            otherJoined.channel_id,
-            otherJoined.persona_name,
-            otherJoined.steam_id,
-            otherJoined);
-  // Add member to cached chatChannels
-  // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-  this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+otherJoined.channel_id); })[0]
-                    .members.push(new Dota2.schema.CMsgDOTAChatMember({
-                                  steam_id: otherJoined.steam_id,
-                                  persona_name: otherJoined.persona_name
-                                }));
+    /* Someone joined a chat channel you're in. */
+    var otherJoined = Dota2.schema.CMsgDOTAOtherJoinedChatChannel.decode(message);
+    var channel = this._getChannelById(otherJoined.channel_id);
+    if (this.debug) util.log(otherJoined.steam_id + " joined channel " + channel.channel_name);
+    this.emit("chatJoin",
+        channel.channel_name,
+        otherJoined.persona_name,
+        otherJoined.steam_id,
+        otherJoined);
+    // Add member to cached chatChannels
+    channel.members.push(new Dota2.schema.CMsgDOTAChatMember({
+        steam_id: otherJoined.steam_id,
+        persona_name: otherJoined.persona_name
+    }));
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCOtherJoinedChannel] = onOtherJoinedChannel;
 
 var onOtherLeftChannel = function onOtherLeftChannel(message) {
-  /* Someone left a chat channel you're in. */
-  var otherLeft = Dota2.schema.CMsgDOTAOtherLeftChatChannel.decode(message);
-  if(this.debug) util.log(otherLeft.steam_id+" left channel");
-  this.emit("chatLeave",
-            otherLeft.channel_id,
+    /* Someone left a chat channel you're in. */
+    var otherLeft = Dota2.schema.CMsgDOTAOtherLeftChatChannel.decode(message);
+    var channel = this._getChannelById(otherLeft.channel_id);
+    // Check if it is me that left the channel
+    if ("" + otherLeft.steam_id === "" + this._client.steamID) {
+        if (this.debug) util.log("Left channel " + channel.channel_name);
+        this.emit("chatLeave",
+            channel.channel_name,
             otherLeft.steam_id,
             otherLeft);
-  // Delete member from cached chatChannel
-  // channel_id is a uint64 which is a compound object. Using '===' or '==' doesn't work to check the equality necessitating the cast to String
-  var chatChannel = this.chatChannels.filter(function (item) {return (""+item.channel_id === ""+otherLeft.channel_id); })[0];
-  chatChannel.members = chatChannel.members.filter(function (item) {return (""+item.steam_id !== ""+otherLeft.steam_id); });
+        // Delete channel from cache
+        this.chatChannels = this.chatChannels.filter(function(item) {
+            if ("" + item.channel_id == "" + channel.channel_id) return false;
+        });
+    } else {
+        if (this.debug) util.log(otherLeft.steam_id + " left channel " + channel.channel_name);
+        this.emit("chatLeave",
+            channel.channel_name,
+            otherLeft.steam_id,
+            otherLeft);
+        // Delete member from cached chatChannel
+        channel.members = channel.members.filter(function(item) {
+            return ("" + item.steam_id !== "" + otherLeft.steam_id);
+        });
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCOtherLeftChannel] = onOtherLeftChannel;
 
 var onChatChannelsResponse = function onChatChannelsResponse(message) {
-  var channels = Dota2.schema.CMsgDOTARequestChatChannelListResponse.decode(message).channels;
-  this.emit("chatChannelsData", channels)
+    var channels = Dota2.schema.CMsgDOTARequestChatChannelListResponse.decode(message).channels;
+    this.emit("chatChannelsData", channels)
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestChatChannelListResponse] = onChatChannelsResponse;

--- a/handlers/community.js
+++ b/handlers/community.js
@@ -6,124 +6,121 @@ Dota2._playerHistoryOptions = {
     matches_requested: "number",
     hero_id: "number",
     request_id: "number"
-  };
+};
 
 // Methods
 Dota2.Dota2Client.prototype.requestPlayerMatchHistory = function(account_id, options, callback) {
-  callback = callback || null;
-  options = options || null;
-  var _self = this;
-  /* Sends a message to the Game Coordinator requesting `accountId`'s player match history.  Listen for `playerMatchHistoryData` event for Game Coordinator's response. */
-  if (!this._gcReady) {
-      if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-      return null;
-  }
-
-  if (this.debug) util.log("Sending player match history request");
-  var command = Dota2._parseOptions(options, Dota2._playerHistoryOptions);
-  command.account_id = account_id;
-  command.matches_requested = command.matches_requested || 1;
-  command.request_id = command.request_id || account_id;
-  var payload = new Dota2.schema.CMsgDOTAGetPlayerMatchHistory(command);
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgDOTAGetPlayerMatchHistory;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPlayerMatchHistoryResponse.call(_self, body, callback);
-                }
-  );
+    callback = callback || null;
+    options = options || null;
+    var _self = this;
+    /* Sends a message to the Game Coordinator requesting `accountId`'s player match history.  Listen for `playerMatchHistoryData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending player match history request");
+    
+    var command = Dota2._parseOptions(options, Dota2._playerHistoryOptions);
+    command.account_id = account_id;
+    command.matches_requested = command.matches_requested || 1;
+    command.request_id = command.request_id || account_id;
+    var payload = new Dota2.schema.CMsgDOTAGetPlayerMatchHistory(command);
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgDOTAGetPlayerMatchHistory, 
+                    payload, 
+                    onPlayerMatchHistoryResponse, callback);
 };
 
 Dota2.Dota2Client.prototype.requestProfile = function(account_id, request_name, callback) {
-  callback = callback || null;
-  var _self = this;
-  /* Sends a message to the Game Coordinator requesting `accountId`'s profile data.  Listen for `profileData` event for Game Coordinator's response. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending profile request");
-  var payload = new Dota2.schema.CMsgDOTAProfileRequest({
-    "account_id": account_id,
-    "request_name": request_name,
-    "engine": 1
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCProfileRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onProfileResponse.call(_self, body, callback);
-                }
-  );
+    callback = callback || null;
+    var _self = this;
+    
+    /* Sends a message to the Game Coordinator requesting `accountId`'s profile data.  Listen for `profileData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending profile request");
+    
+    var payload = new Dota2.schema.CMsgDOTAProfileRequest({
+        "account_id": account_id,
+        "request_name": request_name,
+        "engine": 1
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCProfileRequest, 
+                    payload, 
+                    onProfileResponse, callback);
 };
 
 Dota2.Dota2Client.prototype.requestProfileCard = function(account_id, callback) {
-  callback = callback || null;
-  var _self = this;
-  /* Sends a message to the Game Coordinator requesting `accountId`'s profile card.  Listen for `profileCardData` event for Game Coordinator's response. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending profile card request");
-  var payload = new Dota2.schema.CMsgClientToGCGetProfileCard({
-    "account_id": account_id
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetProfileCard;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onProfileCardResponse.call(_self, body, callback);
-                }
-  );
+    callback = callback || null;
+    var _self = this;
+    
+    /* Sends a message to the Game Coordinator requesting `accountId`'s profile card.  Listen for `profileCardData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending profile card request");
+    
+    var payload = new Dota2.schema.CMsgClientToGCGetProfileCard({
+        "account_id": account_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetProfileCard, 
+                    payload, 
+                    onProfileCardResponse, callback);
 };
 
 Dota2.Dota2Client.prototype.requestPassportData = function(account_id, callback) {
-  callback = callback || null;
-  var _self = this;
-  /* Sends a message to the Game Coordinator requesting `accountId`'s passport data.  Listen for `passportData` event for Game Coordinator's response. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending passport data request");
-  var payload = new Dota2.schema.CMsgPassportDataRequest({"account_id": account_id});
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPassportDataRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPassportDataResponse.call(_self, body, callback);
-                }
-  );
+    callback = callback || null;
+    var _self = this;
+    
+    /* Sends a message to the Game Coordinator requesting `accountId`'s passport data.  Listen for `passportData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending passport data request");
+    
+    var payload = new Dota2.schema.CMsgPassportDataRequest({
+        "account_id": account_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPassportDataRequest,
+                    payload,
+                    onPassportDataResponse, callback);
 };
 
 Dota2.Dota2Client.prototype.requestHallOfFame = function(week, callback) {
-  week = week || null;
-  callback = callback || null;
-  var _self = this;
+    week = week || null;
+    callback = callback || null;
+    var _self = this;
 
-  /* Sends a message to the Game Coordinator requesting `accountId`'s passport data.  Listen for `passportData` event for Game Coordinator's response. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending hall of fame request.");
-  var payload = new Dota2.schema.CMsgDOTAHallOfFameRequest({
-    "week": week
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCHallOfFameRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onHallOfFameResponse.call(_self, body, callback);
-                }
-  );
+    /* Sends a message to the Game Coordinator requesting `accountId`'s passport data.  Listen for `passportData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending hall of fame request.");
+    
+    var payload = new Dota2.schema.CMsgDOTAHallOfFameRequest({
+        "week": week
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCHallOfFameRequest, 
+                    payload, 
+                    onHallOfFameResponse, callback);
 };
 
+Dota2.Dota2Client.prototype.requestPlayerInfo = function(account_ids) {
+    account_ids = account_ids || [];
+    account_ids = Array.isArray(account_ids) ? account_ids : [account_ids];
+    if (account_ids.length == 0) {
+        if (this.debug) util.log("Account ids must be a single id or array of ids.");
+        return null;
+    }
+
+    /* Sends a message to the Game Coordinator requesting the player info on all `account_ids`. Listen for `playerInfoData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending player info request.");
+
+    var payload = new Dota2.schema.CMsgGCPlayerInfoRequest({
+        account_ids: account_ids
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPlayerInfoRequest, 
+                    payload);
+};
+
+Dota2.Dota2Client.prototype.requestTrophyList = function(account_id, callback) {
+    account_id = account_id || null;
+    var _self = this;
+
+    /* Sends a message to the Game Coordinator requesting `accountId`'s trophy list. Listen for `trophyListData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending trophy list request.");
+
+    var payload = new Dota2.schema.CMsgClientToGCGetTrophyList({
+        "account_id": account_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetTrophyList,
+                    payload,
+                    onTrophyListResponse, callback);
+};
 
 // Handlers
 
@@ -137,8 +134,7 @@ var onPlayerMatchHistoryResponse = function onPlayerMatchHistoryResponse(message
         if (this.debug) util.log("Received player match history data");
         this.emit("playerMatchHistoryData", matchHistoryResponse.requestId, matchHistoryResponse);
         if (callback) callback(null, matchHistoryResponse);
-    }
-    else {
+    } else {
         if (this.debug) util.log("Received a bad GetPlayerMatchHistoryResponse");
         if (callback) callback(matchHistoryResponse.result, matchHistoryResponse);
     }
@@ -146,53 +142,68 @@ var onPlayerMatchHistoryResponse = function onPlayerMatchHistoryResponse(message
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgDOTAGetPlayerMatchHistoryResponse] = onPlayerMatchHistoryResponse;
 
 var onProfileResponse = function onProfileResponse(message, callback) {
-  callback = callback || null;
-  var profileResponse = Dota2.schema.CMsgDOTAProfileResponse.decode(message);
+    callback = callback || null;
+    var profileResponse = Dota2.schema.CMsgDOTAProfileResponse.decode(message);
 
-  if (profileResponse.result === 1) {
-    if (this.debug) util.log("Received profile data for: " + profileResponse.game_account_client.account_id);
-    this.emit("profileData", profileResponse.game_account_client.account_id, profileResponse);
-    if (callback) callback(null, profileResponse);
-  }
-  else {
-    if (this.debug) util.log("Received a bad profileResponse");
-    if (callback) callback(profileResponse.result, profileResponse);
-  }
+    if (profileResponse.result === 1) {
+        if (this.debug) util.log("Received profile data for: " + profileResponse.game_account_client.account_id);
+        this.emit("profileData", profileResponse.game_account_client.account_id, profileResponse);
+        if (callback) callback(null, profileResponse);
+    } else {
+        if (this.debug) util.log("Received a bad profileResponse");
+        if (callback) callback(profileResponse.result, profileResponse);
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCProfileResponse] = onProfileResponse;
 
 var onProfileCardResponse = function onProfileCardResponse(message, callback) {
-  callback = callback || null;
-  var profileCardResponse = Dota2.schema.CMsgDOTAProfileCard.decode(message);
+    callback = callback || null;
+    var profileCardResponse = Dota2.schema.CMsgDOTAProfileCard.decode(message);
 
-  if (this.debug) util.log("Received profile card data for: " + profileCardResponse.account_id);
-  this.emit("profileCardData", profileCardResponse.account_id, profileCardResponse);
-  if (callback) callback(null, profileCardResponse);
+    if (this.debug) util.log("Received profile card data for: " + profileCardResponse.account_id);
+    this.emit("profileCardData", profileCardResponse.account_id, profileCardResponse);
+    if (callback) callback(null, profileCardResponse);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetProfileCardResponse] = onProfileCardResponse;
 
 var onPassportDataResponse = function onPassportDataResponse(message, callback) {
-  callback = callback || null;
-  var passportDataResponse = Dota2.schema.CMsgPassportDataResponse.decode(message);
+    callback = callback || null;
+    var passportDataResponse = Dota2.schema.CMsgPassportDataResponse.decode(message);
 
-  if (this.debug) util.log("Received passport data for: " + passportDataResponse.account_id);
-  this.emit("passportData", passportDataResponse.account_id, passportDataResponse);
-  if (callback) callback(null, passportDataResponse);
+    if (this.debug) util.log("Received passport data for: " + passportDataResponse.account_id);
+    this.emit("passportData", passportDataResponse.account_id, passportDataResponse);
+    if (callback) callback(null, passportDataResponse);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCPassportDataResponse] = onPassportDataResponse;
 
 var onHallOfFameResponse = function onHallOfFameResponse(message, callback) {
-  callback = callback || null;
-  var hallOfFameResponse = Dota2.schema.CMsgDOTAHallOfFameResponse.decode(message);
+    callback = callback || null;
+    var hallOfFameResponse = Dota2.schema.CMsgDOTAHallOfFameResponse.decode(message);
 
-  if (hallOfFameResponse.eresult === 1) {
-    if (this.debug) util.log("Received hall of fame response for week: " + hallOfFameResponse.hall_of_fame.week);
-    this.emit("hallOfFameData", hallOfFameResponse.hall_of_fame.week, hallOfFameResponse.hall_of_fame.featured_players, hallOfFameResponse.hall_of_fame.featured_farmer, hallOfFameResponse);
-    if (callback) callback(null, hallOfFameResponse);
-  }
-  else {
-      if (this.debug) util.log("Received a bad hall of fame.");
-      if (callback) callback(hallOfFameResponse.result, hallOfFameResponse);
-  }
+    if (hallOfFameResponse.eresult === 1) {
+        if (this.debug) util.log("Received hall of fame response for week: " + hallOfFameResponse.hall_of_fame.week);
+        this.emit("hallOfFameData", hallOfFameResponse.hall_of_fame.week, hallOfFameResponse.hall_of_fame.featured_players, hallOfFameResponse.hall_of_fame.featured_farmer, hallOfFameResponse);
+        if (callback) callback(null, hallOfFameResponse);
+    } else {
+        if (this.debug) util.log("Received a bad hall of fame.");
+        if (callback) callback(hallOfFameResponse.result, hallOfFameResponse);
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCHallOfFameResponse] = onHallOfFameResponse;
+
+var onPlayerInfoResponse = function onPlayerInfoResponse(message) {
+    var playerInfoResponse = Dota2.schema.CMsgGCPlayerInfo.decode(message);
+
+    if (this.debug) util.log("Received new player info data");
+    this.emit("playerInfoData", playerInfoResponse);
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCPlayerInfo] = onPlayerInfoResponse;
+
+var onTrophyListResponse = function onTrophyListResponse(message, callback) {
+    var trophyListResponse = Dota2.schema.CMsgClientToGCGetTrophyListResponse.decode(message);
+
+    if (this.debug) util.log("Received new trophy list data.");
+    this.emit("trophyListData", trophyListResponse);
+    if (callback) callback(null, trophyListResponse);
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetTrophyListResponse] = onTrophyListResponse;

--- a/handlers/custom.js
+++ b/handlers/custom.js
@@ -1,0 +1,24 @@
+var Dota2 = require("../index"),
+    util = require("util");
+    
+Dota2.Dota2Client.prototype.requestJoinableCustomGameModes = function requestJoinableCustomGameModes(server_region) {
+    // Request list of joinable custom games for a certain region
+    server_region = server_region || Dota2.ServerRegion.UNSPECIFIED;
+    
+    if (this.debug) util.log("Sending joinable custom game modes request");
+    var payload = new Dota2.schema.CMsgJoinableCustomGameModesRequest({
+        "server_region": server_region
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinableCustomGameModesRequest, payload);
+}
+
+var handlers = Dota2.Dota2Client.prototype._handlers;
+
+var onJoinableCustomGameModesResponse = function onJoinableCustomGameModesResponse(message, callback) {
+    var modes = Dota2.schema.CMsgJoinableCustomGameModesResponse.decode(message);
+    
+    if (this.debug) util.log("Received joinable custom game modes");
+    this.emit("joinableCustomGameModes", modes.game_modes);
+    if (callback) callback(null, modes);
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinableCustomGameModesResponse] = onJoinableCustomGameModesResponse;

--- a/handlers/guild.js
+++ b/handlers/guild.js
@@ -5,96 +5,65 @@ var Dota2 = require("../index"),
 // Methods
 
 Dota2.Dota2Client.prototype.requestGuildData = function() {
-  /* Asks the GC for info on the users current guilds. Expect k_EMsgGCGuildOpenPartyRefresh and k_EMsgGCGuildData from GC for guild ids. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Requesting current user guild data. ");
-  var payload = new Dota2.schema.CMsgDOTARequestGuildData();
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestGuildData;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    /* Asks the GC for info on the users current guilds. Expect k_EMsgGCGuildOpenPartyRefresh and k_EMsgGCGuildData from GC for guild ids. */
+    if (this.debug) util.log("Requesting current user guild data. ");
+    
+    var payload = new Dota2.schema.CMsgDOTARequestGuildData();
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestGuildData, payload);
 };
 
 Dota2.Dota2Client.prototype.inviteToGuild = function(guild_id, target_account_id, callback) {
-  callback = callback || null;
-  var _self = this;
-  
-  /* Attempts to invite target_account_id to a guild.  Expect k_EMsgGCGuildInviteAccountResponse from GC. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    callback = callback || null;
+    var _self = this;
 
-  if (this.debug) util.log("Inviting person to guild. " + [guild_id, target_account_id].join(", "));
-  var payload = new Dota2.schema.CMsgDOTAGuildInviteAccountRequest({
-    "guild_id": guild_id,
-    "target_account_id": target_account_id
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildInviteAccountRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onGuildInviteResponse.call(_self, body, callback);
-                }
-  );
+    /* Attempts to invite target_account_id to a guild.  Expect k_EMsgGCGuildInviteAccountResponse from GC. */
+    if (this.debug) util.log("Inviting person to guild. " + [guild_id, target_account_id].join(", "));
+    
+    var payload = new Dota2.schema.CMsgDOTAGuildInviteAccountRequest({
+        "guild_id": guild_id,
+        "target_account_id": target_account_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildInviteAccountRequest, 
+                    payload,
+                    onGuildInviteResponse, callback);
 };
 
 Dota2.Dota2Client.prototype.cancelInviteToGuild = function(guild_id, target_account_id, callback) {
-  callback = callback || null;
-  var _self = this;
-  
-  /* Attempts to cancel target_account_id's invitation to a guild.  Expect k_EMsgGCGuildCancelInviteAccountResponse from GC. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    callback = callback || null;
+    var _self = this;
 
-  if (this.debug) util.log("Cancelling invite to guild. " + [guild_id, target_account_id].join(", "));
-  var payload = new Dota2.schema.CMsgDOTAGuildCancelInviteRequest({
-    "guild_id": guild_id,
-    "target_account_id": target_account_id
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildCancelInviteRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onGuildCancelInviteResponse.call(_self, body, callback);
-                }
-  );
+    /* Attempts to cancel target_account_id's invitation to a guild.  Expect k_EMsgGCGuildCancelInviteAccountResponse from GC. */
+    if (this.debug) util.log("Cancelling invite to guild. " + [guild_id, target_account_id].join(", "));
+    
+    var payload = new Dota2.schema.CMsgDOTAGuildCancelInviteRequest({
+        "guild_id": guild_id,
+        "target_account_id": target_account_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildCancelInviteRequest, 
+                    payload,
+                    onGuildCancelInviteResponse, callback);
 };
 
 Dota2.Dota2Client.prototype.setGuildAccountRole = function(guild_id, target_account_id, target_role, callback) {
-  callback = callback || null;
-  var _self = this;
-  /* Attempts to change an account's role in a guild. This can be accepting an invitation or promoting/demoting other guild members. Expect k_EMsgGCGuildSetAccountRoleResponse from GC.
-     Roles:
-     - 0: Kick member from guild.
-     - 1: Leader
-     - 2: Officer
-     - 3: Member
-  */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Setting guild account role. " + [guild_id, target_account_id, target_role].join(", "));
-  var payload = new Dota2.schema.CMsgDOTAGuildSetAccountRoleRequest({
-    "guild_id": guild_id,
-    "target_account_id": target_account_id,
-    "target_role": target_role
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildSetAccountRoleRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onGuildSetAccountRoleResponse.call(_self, body, callback);
-                }
-  );
+    callback = callback || null;
+    var _self = this;
+    /* Attempts to change an account's role in a guild. This can be accepting an invitation or promoting/demoting other guild members. Expect k_EMsgGCGuildSetAccountRoleResponse from GC.
+       Roles:
+       - 0: Kick member from guild.
+       - 1: Leader
+       - 2: Officer
+       - 3: Member
+    */
+    if (this.debug) util.log("Setting guild account role. " + [guild_id, target_account_id, target_role].join(", "));
+    
+    var payload = new Dota2.schema.CMsgDOTAGuildSetAccountRoleRequest({
+        "guild_id": guild_id,
+        "target_account_id": target_account_id,
+        "target_role": target_role
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildSetAccountRoleRequest, 
+                    payload, 
+                    onGuildSetAccountRoleResponse, callback);
 };
 
 
@@ -103,80 +72,80 @@ Dota2.Dota2Client.prototype.setGuildAccountRole = function(guild_id, target_acco
 var handlers = Dota2.Dota2Client.prototype._handlers;
 
 var onGuildOpenPartyRefresh = function onGuildOpenPartyRefresh(message) {
-  /* Response from requestGuildData containing data on open parties, but most notably - it can tell the library what guilds the user is in. */
-  var response = Dota2.schema.CMsgDOTAGuildOpenPartyRefresh.decode(message);
-  if (this.debug) util.log("Got guild open party data");
-  this.emit("guildOpenPartyData", response.guild_id, response.open_parties, response);
+    /* Response from requestGuildData containing data on open parties, but most notably - it can tell the library what guilds the user is in. */
+    var response = Dota2.schema.CMsgDOTAGuildOpenPartyRefresh.decode(message);
+    if (this.debug) util.log("Got guild open party data");
+    this.emit("guildOpenPartyData", response.guild_id, response.open_parties, response);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildOpenPartyRefresh] = onGuildOpenPartyRefresh;
 
 var onGuildDataResponse = function onGuildDataResponse(message) {
-  /* Second response from requestGuildData containing general info on the guild (id, members, invitation, ...) */
-  var response = Dota2.schema.CMsgDOTAGuildSDO.decode(message);
-  if (this.debug) util.log("Got guild data");
-  this.emit("guildData", response.guild_id, response.members, response);
+    /* Second response from requestGuildData containing general info on the guild (id, members, invitation, ...) */
+    var response = Dota2.schema.CMsgDOTAGuildSDO.decode(message);
+    if (this.debug) util.log("Got guild data");
+    this.emit("guildData", response.guild_id, response.members, response);
 };
 
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildData] = onGuildDataResponse;
 
 var onGuildInviteResponse = function onGuildInviteResponse(message, callback) {
-  callback = callback || null;
-  /* Response to inviting another player to a guild.
-  enum EResult {
-    SUCCESS = 0;
-    ERROR_UNSPECIFIED = 1;
-    ERROR_NO_PERMISSION = 2;
-    ERROR_ACCOUNT_ALREADY_INVITED = 3;
-    ERROR_ACCOUNT_ALREADY_IN_GUILD = 4;
-    ERROR_ACCOUNT_TOO_MANY_INVITES = 5;
-    ERROR_GUILD_TOO_MANY_INVITES = 6;
-    ERROR_ACCOUNT_TOO_MANY_GUILDS = 7;
-  } */
-  var response = Dota2.schema.CMsgDOTAGuildInviteAccountResponse.decode(message);
-  if (this.debug) util.log("Guild invite account response: " + response.result);
-  if (callback) callback(null, response);
+    callback = callback || null;
+    /* Response to inviting another player to a guild.
+    enum EResult {
+      SUCCESS = 0;
+      ERROR_UNSPECIFIED = 1;
+      ERROR_NO_PERMISSION = 2;
+      ERROR_ACCOUNT_ALREADY_INVITED = 3;
+      ERROR_ACCOUNT_ALREADY_IN_GUILD = 4;
+      ERROR_ACCOUNT_TOO_MANY_INVITES = 5;
+      ERROR_GUILD_TOO_MANY_INVITES = 6;
+      ERROR_ACCOUNT_TOO_MANY_GUILDS = 7;
+    } */
+    var response = Dota2.schema.CMsgDOTAGuildInviteAccountResponse.decode(message);
+    if (this.debug) util.log("Guild invite account response: " + response.result);
+    if (callback) callback(null, response);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildInviteAccountResponse] = onGuildInviteResponse;
 
 var onGuildCancelInviteResponse = function onGuildCancelInviteResponse(message, callback) {
-  callback = callback || null;
-  /* Response to cancelling another player's invitation to a guild.
-  enum EResult {
-    SUCCESS = 0;
-    ERROR_UNSPECIFIED = 1;
-    ERROR_NO_PERMISSION = 2;
-  } */
-  var response = Dota2.schema.CMsgDOTAGuildCancelInviteResponse.decode(message);
-  if (this.debug) util.log("Guild cancel invite response: " + response.result);
-  if (callback) callback(null, response);
+    callback = callback || null;
+    /* Response to cancelling another player's invitation to a guild.
+    enum EResult {
+      SUCCESS = 0;
+      ERROR_UNSPECIFIED = 1;
+      ERROR_NO_PERMISSION = 2;
+    } */
+    var response = Dota2.schema.CMsgDOTAGuildCancelInviteResponse.decode(message);
+    if (this.debug) util.log("Guild cancel invite response: " + response.result);
+    if (callback) callback(null, response);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildCancelInviteResponse] = onGuildCancelInviteResponse;
 
 var onGuildInviteData = function onGuildInviteData(message) {
-  /* Received an invitation to a guild */
-  var guildInviteData = Dota2.schema.CMsgDOTAGuildInviteData.decode(message);
+    /* Received an invitation to a guild */
+    var guildInviteData = Dota2.schema.CMsgDOTAGuildInviteData.decode(message);
 
-  // Break if it is just info, and not invitation.
-  if (!guildInviteData.invitedToGuild) return;
+    // Break if it is just info, and not invitation.
+    if (!guildInviteData.invitedToGuild) return;
 
-  if (this.debug) util.log("Received invitation to guild: " + guildInviteData.guild_name);
-  this.emit("guildInviteData", guildInviteData.guild_id, guildInviteData.guild_name, guildInviteData.inviter, guildInviteData);
+    if (this.debug) util.log("Received invitation to guild: " + guildInviteData.guild_name);
+    this.emit("guildInviteData", guildInviteData.guild_id, guildInviteData.guild_name, guildInviteData.inviter, guildInviteData);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildInviteData] = onGuildInviteData;
 
 var onGuildSetAccountRoleResponse = function onGuildSetAccountRoleResponse(message, callback) {
-  callback = callback || null;
-  /* Response to setting account role.
-      enum EResult {
-        SUCCESS = 0;
-        ERROR_UNSPECIFIED = 1;
-        ERROR_NO_PERMISSION = 2;
-        ERROR_NO_OTHER_LEADER = 3;
-        ERROR_ACCOUNT_TOO_MANY_GUILDS = 4;
-        ERROR_GUILD_TOO_MANY_MEMBERS = 5;
-      } */
-  var setAccountRoleData = Dota2.schema.CMsgDOTAGuildSetAccountRoleResponse.decode(message);
-  if (this.debug) util.log("Guild setAccountRole response: " + setAccountRoleData.result);
-  if (callback) callback(null, setAccountRoleData);
+    callback = callback || null;
+    /* Response to setting account role.
+        enum EResult {
+          SUCCESS = 0;
+          ERROR_UNSPECIFIED = 1;
+          ERROR_NO_PERMISSION = 2;
+          ERROR_NO_OTHER_LEADER = 3;
+          ERROR_ACCOUNT_TOO_MANY_GUILDS = 4;
+          ERROR_GUILD_TOO_MANY_MEMBERS = 5;
+        } */
+    var setAccountRoleData = Dota2.schema.CMsgDOTAGuildSetAccountRoleResponse.decode(message);
+    if (this.debug) util.log("Guild setAccountRole response: " + setAccountRoleData.result);
+    if (callback) callback(null, setAccountRoleData);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCGuildSetAccountRoleResponse] = onGuildSetAccountRoleResponse;

--- a/handlers/helper.js
+++ b/handlers/helper.js
@@ -1,29 +1,100 @@
 var Dota2 = require("../index"),
     util = require("util");
-    
+
+// Enums
+Dota2.EResult = {
+    k_EResultOK : 1, // success
+    k_EResultFail : 2, // generic failure 
+    k_EResultNoConnection : 3, // no/failed network connection
+    // k_EResultNoConnectionRetry : 4, // OBSOLETE - removed
+    k_EResultInvalidPassword : 5, // password/ticket is invalid
+    k_EResultLoggedInElsewhere : 6, // same user logged in elsewhere
+    k_EResultInvalidProtocolVer : 7, // protocol version is incorrect
+    k_EResultInvalidParam : 8, // a parameter is incorrect
+    k_EResultFileNotFound : 9, // file was not found
+    k_EResultBusy : 10, // called method busy - action not taken
+    k_EResultInvalidState : 11, // called object was in an invalid state
+    k_EResultInvalidName : 12, // name is invalid
+    k_EResultInvalidEmail : 13, // email is invalid
+    k_EResultDuplicateName : 14, // name is not unique
+    k_EResultAccessDenied : 15, // access is denied
+    k_EResultTimeout : 16, // operation timed out
+    k_EResultBanned : 17, // VAC2 banned
+    k_EResultAccountNotFound : 18, // account not found
+    k_EResultInvalidSteamID : 19, // steamID is invalid
+    k_EResultServiceUnavailable : 20, // The requested service is currently unavailable
+    k_EResultNotLoggedOn : 21, // The user is not logged on
+    k_EResultPending : 22, // Request is pending (may be in process, or waiting on third party)
+    k_EResultEncryptionFailure : 23, // Encryption or Decryption failed
+    k_EResultInsufficientPrivilege : 24, // Insufficient privilege
+    k_EResultLimitExceeded : 25, // Too much of a good thing
+    k_EResultRevoked : 26, // Access has been revoked (used for revoked guest passes)
+    k_EResultExpired : 27, // License/Guest pass the user is trying to access is expired
+    k_EResultAlreadyRedeemed : 28, // Guest pass has already been redeemed by account, cannot be acked again
+    k_EResultDuplicateRequest : 29, // The request is a duplicate and the action has already occurred in the past, ignored this time
+    k_EResultAlreadyOwned : 30, // All the games in this guest pass redemption request are already owned by the user
+    k_EResultIPNotFound : 31, // IP address not found
+    k_EResultPersistFailed : 32, // failed to write change to the data store
+    k_EResultLockingFailed : 33, // failed to acquire access lock for this operation
+    k_EResultLogonSessionReplaced : 34,
+    k_EResultConnectFailed : 35,
+    k_EResultHandshakeFailed : 36,
+    k_EResultIOFailure : 37,
+    k_EResultRemoteDisconnect : 38,
+    k_EResultShoppingCartNotFound : 39, // failed to find the shopping cart requested
+    k_EResultBlocked : 40, // a user didn't allow it
+    k_EResultIgnored : 41, // target is ignoring sender
+    k_EResultNoMatch : 42, // nothing matching the request found
+    k_EResultAccountDisabled : 43,
+    k_EResultServiceReadOnly : 44, // this service is not accepting content changes right now
+    k_EResultAccountNotFeatured : 45, // account doesn't have value, so this feature isn't available
+    k_EResultAdministratorOK : 46, // allowed to take this action, but only because requester is admin
+    k_EResultContentVersion : 47, // A Version mismatch in content transmitted within the Steam protocol.
+    k_EResultTryAnotherCM : 48, // The current CM can't service the user making a request, user should try another.
+    k_EResultPasswordRequiredToKickSession : 49, // You are already logged in elsewhere, this cached credential login has failed.
+    k_EResultAlreadyLoggedInElsewhere : 50, // You are already logged in elsewhere, you must wait
+    k_EResultSuspended : 51,
+    k_EResultCancelled : 52,
+    k_EResultDataCorruption : 53,
+    k_EResultDiskFull : 54,
+    k_EResultRemoteCallFailed : 55,
+};
+
+
 // Helper methods
 Dota2._parseOptions = function(options, possibleOptions) {
-  var details, option, type, value;
+    var details, option, type, value;
 
-  details = {};
+    details = {};
 
-  for (option in options) {
-    value = options[option];
-    type = possibleOptions[option];
-    if (type == null) {
-      if (this.debug) {
-        util.log("Option " + option + " is not possible.");
-      }
-      continue;
+    for (option in options) {
+        value = options[option];
+        type = possibleOptions[option];
+        if (type == null) {
+            if (this.debug) {
+                util.log("Option " + option + " is not possible.");
+            }
+            continue;
+        }
+        if (typeof value !== type) {
+            if (this.debug) {
+                util.log("Option " + option + " must be a " + type + ".");
+            }
+            continue;
+        }
+        details[option] = value;
     }
-    if (typeof value !== type) {
-      if (this.debug) {
-        util.log("Option " + option + " must be a " + type + ".");
-      }
-      continue;
-    }
-    details[option] = value;
-  }
 
-  return details;
-}
+    return details;
+};
+
+Dota2._convertCallback = function(handler, callback) {
+    var self = this;
+    if (callback && handler) {
+        return function (header, body) {
+            handler.call(self, body, callback);
+        }
+    } else {
+        return undefined;
+    }
+};

--- a/handlers/inventory.js
+++ b/handlers/inventory.js
@@ -4,32 +4,32 @@ var Dota2 = require("../index"),
 // Methods
 
 Dota2.Dota2Client.prototype.setItemPositions = function(item_positions) {
-  /* Attempts to move inventory items to positions as noted itemPositions - which is interpreted as a [itemid, position] tuple. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Setting item positions.");
-  var payloadItemPositions = item_positions.map(function(item){ return {"itemId": item[0], "position": item[1]}; }),
-    payload = new Dota2.schema.CMsgSetItemPositions({"itemPositions": payloadItemPositions});
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCSetItemPositions;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    /* Attempts to move inventory items to positions as noted itemPositions - which is interpreted as a [itemid, position] tuple. */
+    if (this.debug) util.log("Setting item positions.");
+    
+    var payloadItemPositions = item_positions.map(function(item) {
+            return {
+                "itemId": item[0],
+                "position": item[1]
+            };
+        }),
+        payload = new Dota2.schema.CMsgSetItemPositions({
+            "itemPositions": payloadItemPositions
+        });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCSetItemPositions, payload);
 };
 
 Dota2.Dota2Client.prototype.deleteItem = function(item_id) {
-  /* Attempts to delete item by itemid. */
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-  var buffer = new Buffer(8);
-  buffer.writeUInt64LE(item_id); 
-  this._gc.send({
-          "msg":    Dota2.schema.EGCItemMsg.k_EMsgGCDelete
+    /* Attempts to delete item by itemid. */
+    if (!this._gcReady) {
+        if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
+        return null;
+    }
+    var buffer = new Buffer(8);
+    buffer.writeUInt64LE(item_id);
+    this._gc.send({
+            "msg": Dota2.schema.EGCItemMsg.k_EMsgGCDelete
         },
         buffer
-  );
+    );
 };

--- a/handlers/leagues.js
+++ b/handlers/leagues.js
@@ -4,54 +4,33 @@ var Dota2 = require("../index"),
 // Methods
 
 Dota2.Dota2Client.prototype.requestLeaguesInMonth = function(month, year, callback) {
-  callback = callback || null;
-  var _self = this;
+    callback = callback || null;
+    var _self = this;
 
-  // Month & year default to current time values
-  month = month === undefined ? (new Date()).getMonth() : month;
-  year = year || (new Date()).getFullYear();
+    // Month & year default to current time values
+    month = month === undefined ? (new Date()).getMonth() : month;
+    year = year || (new Date()).getFullYear();
 
-  /* Sends a message to the Game Coordinator requesting the data on the given month's leagues.
-     Listen for `leaguesInMonthResponse` event for the Game Coordinator's response. */
-
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending CMsgDOTALeaguesInMonthRequest");
-  var payload = new Dota2.schema.CMsgDOTALeaguesInMonthRequest({
-    month: month,
-    year: year
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCLeaguesInMonthRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onLeaguesInMonthResponse.call(_self, body, callback);
-                }
-  );
+    /* Sends a message to the Game Coordinator requesting the data on the given month's leagues.
+       Listen for `leaguesInMonthResponse` event for the Game Coordinator's response. */
+    if (this.debug) util.log("Sending CMsgDOTALeaguesInMonthRequest");
+    
+    var payload = new Dota2.schema.CMsgDOTALeaguesInMonthRequest({
+        month: month,
+        year: year
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCLeaguesInMonthRequest, 
+                    payload, 
+                    onLeaguesInMonthResponse, callback);
 };
 
-Dota2.Dota2Client.prototype.requestLeagueInfo = function(){
-  var _self = this;
-  /* Sends a message to the Game Coordinator request the info on all available official leagues */
-  
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-  
-  if (this.debug) util.log("Sending CMsgRequestLeagueInfo");
-  var payload = new Dota2.schema.CMsgRequestLeagueInfo({});
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgRequestLeagueInfo;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onLeagueInfoResponse.call(_self, body);
-                }
-  );
-  
+Dota2.Dota2Client.prototype.requestLeagueInfo = function() {
+    /* Sends a message to the Game Coordinator request the info on all available official leagues */
+    if (this.debug) util.log("Sending CMsgRequestLeagueInfo");
+    
+    var payload = new Dota2.schema.CMsgRequestLeagueInfo({});
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgRequestLeagueInfo, payload);
+
 };
 
 // Handlers
@@ -59,40 +38,39 @@ Dota2.Dota2Client.prototype.requestLeagueInfo = function(){
 var handlers = Dota2.Dota2Client.prototype._handlers;
 
 var onLeaguesInMonthResponse = function onLeaguesInMonthResponse(message, callback) {
-  callback = callback || null;
-  var response = Dota2.schema.CMsgDOTALeaguesInMonthResponse.decode(message);
+    callback = callback || null;
+    var response = Dota2.schema.CMsgDOTALeaguesInMonthResponse.decode(message);
 
-  if (response.eresult === 1) {
-    if (this.debug) util.log("Received leagues in month response " + response.eresult);
-    this.emit("leaguesInMonthData", response.eresult, response);
-    if (callback) callback(null, response);
-  }
-  else {
-      if (this.debug) util.log("Received a bad leaguesInMonthResponse");
-      if (callback) callback(response.eresult, response);
-  }
+    if (response.eresult === 1) {
+        if (this.debug) util.log("Received leagues in month response " + response.eresult);
+        this.emit("leaguesInMonthData", response.eresult, response);
+        if (callback) callback(null, response);
+    } else {
+        if (this.debug) util.log("Received a bad leaguesInMonthResponse");
+        if (callback) callback(response.eresult, response);
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCLeaguesInMonthResponse] = onLeaguesInMonthResponse;
 
 var onLiveLeagueGameUpdate = function onLiveLeagueGameUpdate(message, callback) {
-  callback = callback || null;
-  var response = Dota2.schema.CMsgDOTALiveLeagueGameUpdate.decode(message);
+    callback = callback || null;
+    var response = Dota2.schema.CMsgDOTALiveLeagueGameUpdate.decode(message);
 
-  if(this.debugMore) util.log("Live league games: "+response.live_league_games+".");
-  this.emit("liveLeagueGamesUpdate", response.live_league_games);
-  if(callback) callback(null, response.live_league_games);
+    if (this.debugMore) util.log("Live league games: " + response.live_league_games + ".");
+    this.emit("liveLeagueGamesUpdate", response.live_league_games);
+    if (callback) callback(null, response.live_league_games);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgDOTALiveLeagueGameUpdate] = onLiveLeagueGameUpdate;
 
 var onLeagueInfoResponse = function onLeagueInfoResponse(message) {
-  var response = Dota2.schema.CMsgResponseLeagueInfo.decode(message);
-  
-  if (response.leagues.length > 0) {
-    if (this.debug) util.log("Received information for " + response.leagues.length + " leagues");
-    this.emit("leagueData", response.leagues);
-  } else {
-    if (this.debug) util.log("Received a bad leagueInfo response", response);
-  }
-  
+    var response = Dota2.schema.CMsgResponseLeagueInfo.decode(message);
+
+    if (response.leagues.length > 0) {
+        if (this.debug) util.log("Received information for " + response.leagues.length + " leagues");
+        this.emit("leagueData", response.leagues);
+    } else {
+        if (this.debug) util.log("Received a bad leagueInfo response", response);
+    }
+
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgResponseLeagueInfo] = onLeagueInfoResponse;

--- a/handlers/lobbies.js
+++ b/handlers/lobbies.js
@@ -1,11 +1,18 @@
 var Dota2 = require("../index"),
     util = require("util");
 
+Dota2.SeriesType = {
+    NONE: 0,
+    BEST_OF_THREE: 1,
+    BEST_OF_FIVE: 2
+};
+
 Dota2._lobbyOptions = {
     game_name: "string",
     server_region: "number",
     game_mode: "number",
     game_version: "number",
+    cm_pick: "number",
     allow_cheats: "boolean",
     fill_with_bots: "boolean",
     allow_spectating: "boolean",
@@ -20,127 +27,88 @@ Dota2._lobbyOptions = {
     custom_map_name: "string",
     custom_difficulty: "number",
     custom_game_id: "number",
-  };
+};
 
 // Methods
 Dota2.Dota2Client.prototype.createPracticeLobby = function(password, options, callback) {
-  callback = callback || null;
-  this.createTournamentLobby(password, -1, -1, options, callback);
-}
-// callback to onPracticeLobbyResponse
+        callback = callback || null;
+        this.createTournamentLobby(password, -1, -1, options, callback);
+    }
+    // callback to onPracticeLobbyResponse
 Dota2.Dota2Client.prototype.createTournamentLobby = function(password, tournament_game_id, tournament_id, options, callback) {
-  callback = callback || null;
-  password = password || "";
-  tournament_game_id = tournament_game_id || -1;
-  tournament_id = tournament_id || -1;
-  var _self = this;
+    callback = callback || null;
+    password = password || "";
+    tournament_game_id = tournament_game_id || -1;
+    tournament_id = tournament_id || -1;
+    var _self = this;
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    if (this.debug) util.log("Sending match CMsgPracticeLobbyCreate request");
+    var lobby_details = Dota2._parseOptions(options, Dota2._lobbyOptions);
+    lobby_details.pass_key = password;
+    var command = {
+        "lobby_details": lobby_details,
+        "pass_key": password
+    };
 
-  if (this.debug) util.log("Sending match CMsgPracticeLobbyCreate request");
-  var lobby_details = Dota2._parseOptions(options, Dota2._lobbyOptions);
-  lobby_details.pass_key = password;
-  var command = {
-    "lobby_details": lobby_details,
-    "pass_key": password
-  };
+    if (tournament_game_id > 0) {
+        command["tournament_game"] = true;
+        command["tournament_game_id"] = tournament_game_id;
+        command["tournament_id"] = tournament_id;
+    }
+    var payload = new Dota2.schema.CMsgPracticeLobbyCreate(command);
 
-  if (tournament_game_id > 0) {
-    command["tournament_game"] = true;
-    command["tournament_game_id"] = tournament_game_id;
-    command["tournament_id"] = tournament_id;
-  }
-  var payload = new Dota2.schema.CMsgPracticeLobbyCreate(command);
-
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyCreate;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyResponse.call(_self, body, callback);
-                }
-  );
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyCreate, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
 };
 // callback to onPracticeLobbyResponse
-Dota2.Dota2Client.prototype.configPracticeLobby = function(lobby_id, options, callback){
-  callback = callback || null;
-  var _self = this;
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+Dota2.Dota2Client.prototype.configPracticeLobby = function(lobby_id, options, callback) {
+    callback = callback || null;
+    var _self = this;
 
-  var command = Dota2._parseOptions(options);
-  command["lobby_id"] = lobby_id;
+    var command = Dota2._parseOptions(options, Dota2._lobbyOptions);
+    command["lobby_id"] = lobby_id;
 
-  var payload = new Dota2.schema.CMsgPracticeLobbySetDetails(command);
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbySetDetails;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyResponse.call(_self, body, callback);
-                }
-  );
+    var payload = new Dota2.schema.CMsgPracticeLobbySetDetails(command);
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbySetDetails,
+                    payload, 
+                    onPracticeLobbyResponse, callback);
 };
 // callback to onPracticeLobbyListResponse
-Dota2.Dota2Client.prototype.requestPracticeLobbyList = function(callback){
-  callback = callback || null;
-  var _self = this;
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+Dota2.Dota2Client.prototype.requestPracticeLobbyList = function(callback) {
+    callback = callback || null;
+    var _self = this;
 
-  if (this.debug) util.log("Sending CMsgPracticeLobbyList request");
-  var payload = new Dota2.schema.CMsgPracticeLobbyList({
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyList;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyListResponse.call(_self, body, callback);
-                }
-  );
+    if (this.debug) util.log("Sending CMsgPracticeLobbyList request");
+    
+    var payload = new Dota2.schema.CMsgPracticeLobbyList({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyList, 
+                    payload, 
+                    onPracticeLobbyListResponse, callback);
 };
 // callback to onFriendPracticeLobbyListResponse
-Dota2.Dota2Client.prototype.requestFriendPracticeLobbyList = function(callback){
-  callback = callback || null;
-  var _self = this;
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+Dota2.Dota2Client.prototype.requestFriendPracticeLobbyList = function(callback) {
+    callback = callback || null;
+    var _self = this;
 
-  if (this.debug) util.log("Sending CMsgFriendPracticeLobbyListRequest request");
-  var payload = new Dota2.schema.CMsgFriendPracticeLobbyListRequest({
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCFriendPracticeLobbyListRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onFriendPracticeLobbyListResponse.call(_self, body, callback);
-                }
-  );
+    if (this.debug) util.log("Sending CMsgFriendPracticeLobbyListRequest request");
+    
+    var payload = new Dota2.schema.CMsgFriendPracticeLobbyListRequest({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCFriendPracticeLobbyListRequest, 
+                    payload, 
+                    onFriendPracticeLobbyListResponse, callback);
 };
 // callback to onPracticeLobbyResponse
-Dota2.Dota2Client.prototype.balancedShuffleLobby = function(callback){
-  callback = callback || null;
-  var _self = this;
-
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-  var payload = new Dota2.schema.CMsgBalancedShuffleLobby({});
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCBalancedShuffleLobby;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyResponse.call(_self, body, callback);
-                }
-  );
+Dota2.Dota2Client.prototype.balancedShuffleLobby = function(callback) {
+    callback = callback || null;
+    var _self = this;
+    
+    if (this.debug) util.log("Sending CMsgBalancedShuffleLobby request");
+    
+    var payload = new Dota2.schema.CMsgBalancedShuffleLobby({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCBalancedShuffleLobby, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
 };
 
 //TODO: figure out the enum for team
@@ -155,8 +123,9 @@ Dota2.Dota2Client.prototype.setLobbyTeamSlot = function(team, slot, callback){
   if (this.debug) util.log("Sending flip teams request");
   var payload = Dota2.schema.CMsgFlipLobbyTeams.serialize({});
 
-  this._gc.send({
-          "msg":    Dota2.schema.EDOTAGCMsg.k_EMsgGCFlipLobbyTeams, 
+  this._gc.send(
+  {
+          "msg":    Dota2.schema.EDOTAGCMsg.k_EMsgGCFlipLobbyTeams,
           "proto":  {
             "client_steam_id": this._client.steamID,
             "source_app_id":  this._appid
@@ -167,190 +136,232 @@ Dota2.Dota2Client.prototype.setLobbyTeamSlot = function(team, slot, callback){
   );
 };*/
 // callback to onPracticeLobbyResponse
-Dota2.Dota2Client.prototype.flipLobbyTeams = function(callback){
-  callback = callback || null;
-  var _self = this;
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+Dota2.Dota2Client.prototype.flipLobbyTeams = function(callback) {
+    callback = callback || null;
+    var _self = this;
 
-  if (this.debug) util.log("Sending flip teams request");
-  var payload = new Dota2.schema.CMsgFlipLobbyTeams({});
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCFlipLobbyTeams;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyResponse.call(_self, body, callback);
-                }
-  );
+    if (this.debug) util.log("Sending flip teams request");
+    
+    var payload = new Dota2.schema.CMsgFlipLobbyTeams({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCFlipLobbyTeams, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
 };
 
-Dota2.Dota2Client.prototype.inviteToLobby = function(steam_id){
-  steam_id = steam_id || null;
+Dota2.Dota2Client.prototype.inviteToLobby = function(steam_id) {
+    steam_id = steam_id || null;
+    if (steam_id == null) {
+        if (this.debug) util.log("Steam ID required to create a lobby invite.");
+        return null;
+    }
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (steam_id == null) {
-    if (this.debug) util.log("Steam ID required to create a lobby invite.");
-    return null;
-  }
-
-  if (this.debug) util.log("Inviting "+steam_id+" to a lobby.");
-  // todo: set client version here?
-  var payload = new Dota2.schema.CMsgInviteToLobby({
-    "steam_id": steam_id
-  });
-  this._protoBufHeader.msg = Dota2.schema.EGCBaseMsg.k_EMsgGCInviteToLobby;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
-  
+    if (this.debug) util.log("Inviting " + steam_id + " to a lobby.");
+    // todo: set client version here?
+    var payload = new Dota2.schema.CMsgInviteToLobby({
+        "steam_id": steam_id
+    });
+    this.sendToGC(Dota2.schema.EGCBaseMsg.k_EMsgGCInviteToLobby, payload);
 };
 // callback to onPracticeLobbyResponse
-Dota2.Dota2Client.prototype.practiceLobbyKick = function(account_id, callback){
-  callback = callback || null;
-  var _self = this;
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+Dota2.Dota2Client.prototype.practiceLobbyKick = function(account_id, callback) {
+    callback = callback || null;
+    account_id = account_id || "";
+    var _self = this;
 
-  account_id = account_id || "";
+    if (this.debug) util.log("Sending match CMsgPracticeLobbyKick request");
+    
+    var payload = new Dota2.schema.CMsgPracticeLobbyKick({
+        "account_id": account_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyKick, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
+};
+// callback to onPracticeLobbyResponse
+Dota2.Dota2Client.prototype.practiceLobbyKickFromTeam = function(account_id, callback) {
+    callback = callback || null;
+    account_id = account_id || "";
+    var _self = this;
 
-  if (this.debug) util.log("Sending match CMsgPracticeLobbyKick request");
-  var payload = new Dota2.schema.CMsgPracticeLobbyKick({
-    "account_id": account_id
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyKick;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyResponse.call(_self, body, callback);
-                }
-  );
+    if (this.debug) util.log("Sending match CMsgPracticeLobbyKickFromTeam request");
+    
+    var payload = new Dota2.schema.CMsgPracticeLobbyKickFromTeam({
+        "account_id": account_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyKickFromTeam, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
 };
 // callback to onPracticeLobbyJoinResponse
-Dota2.Dota2Client.prototype.joinPracticeLobby = function(id, password, callback){
-  callback = callback || null;
-  var _self = this;
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+Dota2.Dota2Client.prototype.joinPracticeLobby = function(id, password, callback) {
+    callback = callback || null;
+    password = password || "";
+    var _self = this;
 
-  password = password || "";
-
-  if (this.debug) util.log("Sending match CMsgPracticeLobbyJoin request");
-  var payload = new Dota2.schema.CMsgPracticeLobbyJoin({
-    "lobby_id": id,
-    "pass_key": password
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyJoin;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyJoinResponse.call(_self, body, callback);
-                }
-  );
+    if (this.debug) util.log("Sending match CMsgPracticeLobbyJoin request");
+    
+    var payload = new Dota2.schema.CMsgPracticeLobbyJoin({
+        "lobby_id": id,
+        "pass_key": password
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyJoin, 
+                    payload, 
+                    onPracticeLobbyJoinResponse, callback);
 };
 // callback to onPracticeLobbyResponse
 Dota2.Dota2Client.prototype.leavePracticeLobby = function(callback) {
-  callback = callback || null;
-  var _self = this;
+    callback = callback || null;
+    var _self = this;
 
-  /* Sends a message to the Game Coordinator requesting `matchId`'s match details.  Listen for `matchData` event for Game Coordinator's response. */
+    /* Sends a message to the Game Coordinator requesting `matchId`'s match details.  Listen for `matchData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending match CMsgPracticeLobbyLeave request");
+    
+    var payload = new Dota2.schema.CMsgPracticeLobbyLeave({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyLeave, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
+};
+// callback to onPracticeLobbyResponse
+Dota2.Dota2Client.prototype.abandonCurrentGame = function(callback) {
+    callback = callback || null;
+    var _self = this;
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    if (this.debug) util.log("Sending match CMsgAbandonCurrentGame request");
 
-  if (this.debug) util.log("Sending match CMsgPracticeLobbyLeave request");
-  var payload = new Dota2.schema.CMsgPracticeLobbyLeave({
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyLeave;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyResponse.call(_self, body, callback);
-                }
-  );
+    var payload = new Dota2.schema.CMsgAbandonCurrentGame({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCAbandonCurrentGame,
+                    payload,
+                    onPracticeLobbyResponse, callback);
 };
 // callback to onPracticeLobbyResponse
 Dota2.Dota2Client.prototype.launchPracticeLobby = function(callback) {
-  callback = callback || null;
-  var _self = this;
-  /* Sends a message to the Game Coordinator requesting lobby start. */
+    callback = callback || null;
+    var _self = this;
+    /* Sends a message to the Game Coordinator requesting lobby start. */
+    if (this.debug) util.log("Sending match CMsgPracticeLobbyLaunch request");
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending match CMsgPracticeLobbyLaunch request");
-  var payload = new Dota2.schema.CMsgPracticeLobbyLaunch({
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyLaunch;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onPracticeLobbyResponse.call(_self, body, callback);
-                }
-  );
+    var payload = new Dota2.schema.CMsgPracticeLobbyLaunch({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyLaunch, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
 };
+// callback to onPracticeLobbyResponse
+Dota2.Dota2Client.prototype.joinPracticeLobbyTeam = function(slot, team, callback) {
+    callback = callback || null;
+    slot = slot ||1;
+    if (typeof team === 'undefined') team = Dota2.schema.DOTA_GC_TEAM.DOTA_GC_TEAM_PLAYER_POOL;
+    
+    var _self = this;
 
+    if (this.debug) util.log("Sending match CMsgPracticeLobbySetTeamSlot request");
+    
+    var payload = new Dota2.schema.CMsgPracticeLobbySetTeamSlot({
+        "team": team,
+        "slot": slot
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbySetTeamSlot, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
+}
+// callback to onPracticeLobbyResponse
+Dota2.Dota2Client.prototype.addBotToPracticeLobby = function(slot, team, bot_difficulty, callback) {
+    callback = callback || null;
+    slot = slot || 1;
+    team = team || Dota2.schema.DOTA_GC_TEAM.DOTA_GC_TEAM_GOOD_GUYS;
+    bot_difficulty = bot_difficulty || Dota2.schema.DOTABotDifficulty.BOT_DIFFICULTY_PASSIVE;
+    var _self = this;
+
+    if (this.debug) util.log("Sending match CMsgPracticeLobbySetTeamSlot request");
+    
+    var payload = new Dota2.schema.CMsgPracticeLobbySetTeamSlot({
+        "team": team,
+        "slot": slot,
+        "bot_difficulty": bot_difficulty
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbySetTeamSlot, 
+                    payload, 
+                    onPracticeLobbyResponse, callback);
+}
+// no callback
+Dota2.Dota2Client.prototype.respondLobbyInvite = function(id, accept) {
+    id = id || null;
+    accept = accept || false;
+    if (id == null) {
+        if (this.debug) util.log("Lobby ID required to respond to an invite.");
+        return null;
+    }
+
+    if (this.debug) util.log("Responding to lobby invite " + id + ", accept: " + accept);
+    // todo: set client version here?
+    var payload = new Dota2.schema.CMsgLobbyInviteResponse({
+        "lobby_id": id,
+        "accept": accept
+    });
+    this.sendToGC(Dota2.schema.EGCBaseMsg.k_EMsgGCLobbyInviteResponse, payload);
+};
 
 // Handlers
 
 var handlers = Dota2.Dota2Client.prototype._handlers;
 
 var onPracticeLobbyJoinResponse = function onPracticeLobbyJoinResponse(message, callback) {
-  callback = callback || null;
-  var practiceLobbyJoinResponse = Dota2.schema.CMsgPracticeLobbyJoinResponse.decode(message);
+    callback = callback || null;
+    var practiceLobbyJoinResponse = Dota2.schema.CMsgPracticeLobbyJoinResponse.decode(message);
 
-  if (this.debug) util.log("Received practice lobby join response " + practiceLobbyJoinResponse.result);
-  this.emit("practiceLobbyJoinResponse", practiceLobbyJoinResponse.result, practiceLobbyJoinResponse);
-  if (callback) callback(practiceLobbyJoinResponse.result, practiceLobbyJoinResponse);
+    if (this.debug) util.log("Received practice lobby join response " + practiceLobbyJoinResponse.result);
+    this.emit("practiceLobbyJoinResponse", practiceLobbyJoinResponse.result, practiceLobbyJoinResponse);
+    
+    if (callback) {
+        if (practiceLobbyJoinResponse.result === Dota2.schema.DOTAJoinLobbyResult.DOTA_JOIN_RESULT_SUCCESS) {
+            callback(null, practiceLobbyJoinResponse);
+        } else {
+            callback(practiceLobbyJoinResponse.result, practiceLobbyJoinResponse);
+        }
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyJoinResponse] = onPracticeLobbyJoinResponse;
 
 var onPracticeLobbyListResponse = function onPracticeLobbyListResponse(message, callback) {
-  var practiceLobbyListResponse = Dota2.schema.CMsgPracticeLobbyListResponse.decode(message);
+    var practiceLobbyListResponse = Dota2.schema.CMsgPracticeLobbyListResponse.decode(message);
 
-  if (this.debug) util.log("Received practice lobby list response " + practiceLobbyListResponse);
-  this.emit("practiceLobbyListData", null, practiceLobbyListResponse);
-  if (callback) callback(null, practiceLobbyListResponse);
+    if (this.debug) util.log("Received practice lobby list response " + practiceLobbyListResponse);
+    this.emit("practiceLobbyListData", null, practiceLobbyListResponse);
+    if (callback) callback(null, practiceLobbyListResponse);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyListResponse] = onPracticeLobbyListResponse;
 
-var onPracticeLobbyResponse = function onPracticeLobbyResponse(message, callback){
-  var practiceLobbyResponse = Dota2.schema.CMsgPracticeLobbyJoinResponse.decode(message);
+var onPracticeLobbyResponse = function onPracticeLobbyResponse(message, callback) {
+    var practiceLobbyResponse = Dota2.schema.CMsgPracticeLobbyJoinResponse.decode(message);
 
-  if(this.debug) util.log("Received create/flip/shuffle/kick/launch/leave response "+JSON.stringify(practiceLobbyResponse));
-  this.emit("practiceLobbyResponse", practiceLobbyResponse.result, practiceLobbyResponse);
-  if(callback) callback(practiceLobbyResponse.result, practiceLobbyResponse);
+    if (this.debug) util.log("Received create/flip/shuffle/kick/launch/leave response " + JSON.stringify(practiceLobbyResponse));
+    this.emit("practiceLobbyResponse", practiceLobbyResponse.result, practiceLobbyResponse);
+    
+    if (callback) {
+        if (practiceLobbyResponse.result === 1) {
+            callback(null, practiceLobbyResponse); 
+        } else {
+            callback(practiceLobbyResponse.result, practiceLobbyResponse); 
+        }
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCPracticeLobbyResponse] = onPracticeLobbyResponse;
 
 var onFriendPracticeLobbyListResponse = function onFriendPracticeLobbyListResponse(message, callback) {
-  var practiceLobbyListResponse = Dota2.schema.CMsgFriendPracticeLobbyListResponse.decode(message);
+    var practiceLobbyListResponse = Dota2.schema.CMsgFriendPracticeLobbyListResponse.decode(message);
 
-  if (this.debug) util.log("Received friend practice lobby list response " + JSON.stringify(practiceLobbyListResponse));
-  this.emit("friendPracticeLobbyListData", null, practiceLobbyListResponse);
-  if (callback) callback(null, practiceLobbyListResponse);
+    if (this.debug) util.log("Received friend practice lobby list response " + JSON.stringify(practiceLobbyListResponse));
+    this.emit("friendPracticeLobbyListData", null, practiceLobbyListResponse);
+    if (callback) callback(null, practiceLobbyListResponse);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCFriendPracticeLobbyListResponse] = onFriendPracticeLobbyListResponse;
 
 var onInviteCreated = function onInviteCreated(message) {
-  var inviteCreated = Dota2.schema.CMsgInvitationCreated.decode(message);
-  var is_online = !inviteCreated.user_offline;
+    var inviteCreated = Dota2.schema.CMsgInvitationCreated.decode(message);
+    var is_online = !inviteCreated.user_offline;
 
-  if (this.debug && is_online) util.log("Created invitation to online user " + this.ToAccountID(inviteCreated.steam_id));
-  if (this.debug && !is_online) util.log("Created invitation to offline user " + this.ToAccountID(inviteCreated.steam_id));
-  this.emit("inviteCreated", inviteCreated.steam_id, inviteCreated.group_id, is_online);
+    if (this.debug && is_online) util.log("Created invitation to online user " + inviteCreated.steam_id);
+    if (this.debug && !is_online) util.log("Created invitation to offline user " + inviteCreated.steam_id);
+    this.emit("inviteCreated", inviteCreated.steam_id, inviteCreated.group_id, is_online);
 }
 handlers[Dota2.schema.EGCBaseMsg.k_EMsgGCInvitationCreated] = onInviteCreated;
+

--- a/handlers/match.js
+++ b/handlers/match.js
@@ -1,108 +1,61 @@
 var Dota2 = require("../index"),
     util = require("util");
 
+Dota2._matchOptions = {
+        hero_id: "number",
+        game_mode: "number",
+        date_min: "number",
+        date_max: "number",
+        matches_requested: "number",
+        start_at_match_id: "number",
+        min_players: "number",
+        tournament_games_only: "boolean",
+        account_id: "number",
+        league_id: "number",
+        skill: "number",
+        team_id: "number"
+};
+
 // Methods
 Dota2.Dota2Client.prototype.requestMatches = function(criteria, callback) {
-  criteria = criteria || [];
-  callback = callback || null;
-  var _self = this;
+    criteria = criteria || [];
+    callback = callback || null;
+    var _self = this;
+    
     /* Sends a message to the Game Coordinator requesting a list of matches based on the given criteria. Listen for `matchData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending match request");
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    var matchOptions = Dota2._parseOptions(criteria, Dota2._matchOptions);
+    matchOptions.matches_requested = matchOptions.matches_requested || 1;
 
-  if (this.debug) util.log("Sending match request");
-
-  var config, criterium, possibleCriteria, type, value;
-
-  config = {matches_requested:1};
-
-  possibleCriteria = {
-    hero_id: "number",
-    game_mode: "number",
-    date_min: "number",
-    date_max: "number",
-    matches_requested: "number",
-    start_at_match_id: "number",
-    min_players: "number",
-    tournament_games_only: "boolean",
-    account_id: "number",
-    league_id: "number",
-    skill: "number",
-    team_id: "number"
-  };
-
-  for (criterium in criteria) {
-    value = criteria[criterium];
-    type = possibleCriteria[criterium];
-    if (type == null) {
-      if (this.debug) {
-        util.log("Match criterium " + criterium + " is not possible.");
-      }
-      continue;
-    }
-    if (typeof value !== type) {
-      if (this.debug) {
-        util.log("Match criterium " + criterium + " must be a " + type + ".");
-      }
-      continue;
-    }
-    config[criterium] = value;
-  }
-
-  var payload = new Dota2.schema.CMsgDOTARequestMatches(config);
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestMatches;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onMatchesResponse.call(_self, body, callback);
-                }
-  );
-
+    var payload = new Dota2.schema.CMsgDOTARequestMatches(matchOptions);
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestMatches, 
+                    payload, 
+                    onMatchesResponse, callback);
 }
 
 Dota2.Dota2Client.prototype.requestMatchDetails = function(match_id, callback) {
-  callback = callback || null;
-  var _self = this;
-  /* Sends a message to the Game Coordinator requesting `match_id`'s match details.  Listen for `matchData` event for Game Coordinator's response. */
-
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending match details request");
-  var payload = new Dota2.schema.CMsgGCMatchDetailsRequest({
-    "match_id": match_id
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCMatchDetailsRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onMatchDetailsResponse.call(_self, body, callback);
-                }
-  );
+    callback = callback || null;
+    var _self = this;
+    
+    /* Sends a message to the Game Coordinator requesting `match_id`'s match details.  Listen for `matchData` event for Game Coordinator's response. */
+    if (this.debug) util.log("Sending match details request");
+    
+    var payload = new Dota2.schema.CMsgGCMatchDetailsRequest({
+        "match_id": match_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCMatchDetailsRequest, 
+                    payload, 
+                    onMatchDetailsResponse, callback);
 };
 
 Dota2.Dota2Client.prototype.requestMatchmakingStats = function() {
-  /* Sends a message to the Game Coordinator requesting `match_id`'s match deails.  Listen for `matchData` event for Game Coordinator's response. */
-  // Is not Job ID based - can't do callbacks.
-
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (this.debug) util.log("Sending matchmaking stats request");
-  var payload = new Dota2.schema.CMsgDOTAMatchmakingStatsRequest({
-  });
-  this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCMatchmakingStatsRequest;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
-
+    /* Sends a message to the Game Coordinator requesting `match_id`'s match deails.  Listen for `matchData` event for Game Coordinator's response. */
+    // Is not Job ID based - can't do callbacks.
+    if (this.debug) util.log("Sending matchmaking stats request");
+    
+    var payload = new Dota2.schema.CMsgDOTAMatchmakingStatsRequest({});
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCMatchmakingStatsRequest, payload);
 };
 
 
@@ -111,51 +64,50 @@ Dota2.Dota2Client.prototype.requestMatchmakingStats = function() {
 var handlers = Dota2.Dota2Client.prototype._handlers;
 
 var onMatchesResponse = function onMatchesResponse(message, callback) {
-  callback = callback || null;
-  var matchResponse = Dota2.schema.CMsgDOTARequestMatchesResponse.decode(message);
-  if (matchResponse.total_results > 1) {
-    if (this.debug) util.log("Reveived listing for matches");
-    this.emit("matchesData",
-              matchResponse.total_results,
-              matchResponse.results_remaining,
-              matchResponse.matches,
-              matchResponse.series,
-              matchResponse);
-    if (callback) callback(null, matchResponse);
-  } else {
-      if (this.debug) util.log("Received a bad matchesResponse");
-      if (callback) callback(matchResponse.result, matchResponse);
-  }
+    callback = callback || null;
+    var matchResponse = Dota2.schema.CMsgDOTARequestMatchesResponse.decode(message);
+    if (matchResponse.total_results > 1) {
+        if (this.debug) util.log("Reveived listing for matches");
+        this.emit("matchesData",
+            matchResponse.total_results,
+            matchResponse.results_remaining,
+            matchResponse.matches,
+            matchResponse.series,
+            matchResponse);
+        if (callback) callback(null, matchResponse);
+    } else {
+        if (this.debug) util.log("Received a bad matchesResponse");
+        if (callback) callback(matchResponse.result, matchResponse);
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestMatchesResponse] = onMatchesResponse;
 
 var onMatchDetailsResponse = function onMatchDetailsResponse(message, callback) {
-  callback = callback || null;
-  var matchDetailsResponse = Dota2.schema.CMsgGCMatchDetailsResponse.decode(message);
+    callback = callback || null;
+    var matchDetailsResponse = Dota2.schema.CMsgGCMatchDetailsResponse.decode(message);
 
-  if (matchDetailsResponse.result === 1) {
-    /*if (this.debug)*/ util.log("Received match data for: " + matchDetailsResponse.match.match_id);
-    this.emit("matchDetailsData",
-              matchDetailsResponse.match.match_id,
-              matchDetailsResponse);
-    if (callback) callback(null, matchDetailsResponse);
-  }
-  else {
-      if (this.debug) util.log("Received a bad matchDetailsResponse");
-      if (callback) callback(matchDetailsResponse.result, matchDetailsResponse);
-  }
+    if (matchDetailsResponse.result === 1) {
+        /*if (this.debug)*/
+        util.log("Received match data for: " + matchDetailsResponse.match.match_id);
+        this.emit("matchDetailsData",
+            matchDetailsResponse.match.match_id,
+            matchDetailsResponse);
+        if (callback) callback(null, matchDetailsResponse);
+    } else {
+        if (this.debug) util.log("Received a bad matchDetailsResponse");
+        if (callback) callback(matchDetailsResponse.result, matchDetailsResponse);
+    }
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCMatchDetailsResponse] = onMatchDetailsResponse;
 
 var onMatchmakingStatsResponse = function onMatchmakingStatsResponse(message) {
-  // Is not Job ID based - can't do callbacks.
-  var matchmakingStatsResponse = Dota2.schema.CMsgDOTAMatchmakingStatsResponse.decode(message);
+    // Is not Job ID based - can't do callbacks.
+    var matchmakingStatsResponse = Dota2.schema.CMsgDOTAMatchmakingStatsResponse.decode(message);
 
-  if (this.debug) util.log("Received matchmaking stats");
-  this.emit("matchmakingStatsData",
-            matchmakingStatsResponse.wait_times_by_group,
-            matchmakingStatsResponse.searching_players_by_group,
-            matchmakingStatsResponse.disabled_groups,
-            matchmakingStatsResponse);
+    if (this.debug) util.log("Received matchmaking stats");
+    this.emit("matchmakingStatsData",
+        matchmakingStatsResponse.searching_players_by_group_source2,
+        matchmakingStatsResponse.disabled_groups_source2,
+        matchmakingStatsResponse);
 };
 handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCMatchmakingStatsResponse] = onMatchmakingStatsResponse;

--- a/handlers/parties.js
+++ b/handlers/parties.js
@@ -3,117 +3,75 @@ var Dota2 = require("../index"),
 
 // Methods
 Dota2.Dota2Client.prototype.respondPartyInvite = function(id, accept) {
-  id = id || null;
-  accept = accept || false;
+    id = id || null;
+    accept = accept || false;
+    if (id == null) {
+        if (this.debug) util.log("Party ID required to respond to an invite.");
+        return null;
+    }
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (id == null) {
-    if (this.debug) util.log("Party ID required to respond to an invite.");
-    return null;
-  }
-
-  if (this.debug) util.log("Responding to party invite "+id+", accept: "+accept);
-  // todo: set client version here?
-  var payload = new Dota2.schema.CMsgPartyInviteResponse({
-    "party_id": id,
-    "accept": accept,
-    "as_coach": false,
-    "team_id": 0,
-    "game_language_enum": 1,
-    "game_language_name": "english"
-  });
-  this._protoBufHeader.msg = Dota2.EGCBaseMsg.k_EMsgGCPartyInviteResponse;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    if (this.debug) util.log("Responding to party invite " + id + ", accept: " + accept);
+    // todo: set client version here?
+    var payload = new Dota2.schema.CMsgPartyInviteResponse({
+        "party_id": id,
+        "accept": accept,
+        "as_coach": false,
+        "team_id": 0,
+        "game_language_enum": 1,
+        "game_language_name": "english"
+    });
+    this.sendToGC(Dota2.schema.EGCBaseMsg.k_EMsgGCPartyInviteResponse, payload);
 };
 
 Dota2.Dota2Client.prototype.leaveParty = function() {
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    if (this.debug) util.log("Leaving party.");
 
-  if (this.debug) util.log("Leaving party.");
-
-  var payload = new Dota2.schema.CMsgLeaveParty({});
-  this.Party = null;
-  this._protoBufHeader.msg = Dota2.EGCBaseMsg.k_EMsgGCLeaveParty;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    var payload = new Dota2.schema.CMsgLeaveParty({});
+    this.Party = null;
+    this.sendToGC(Dota2.schema.EGCBaseMsg.k_EMsgGCLeaveParty, payload);
 };
 
 Dota2.Dota2Client.prototype.setPartyCoach = function(coach) {
-  coach = coach || false;
+    coach = coach || false;
+    if (this.Party == null) {
+        if (this.debug) util.log("setPartyCoach called when not in a party!");
+        return null;
+    }
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
+    if (this.debug) util.log("Setting coach slot: " + coach);
 
-  if(this.Party == null) {
-    if(this.debug) util.log("setPartyCoach called when not in a party!");
-    return null;
-  }
-
-  if (this.debug) util.log("Setting coach slot: "+coach);
-
-  var payload = new Dota2.schema.CMsgDOTAPartyMemberSetCoach({"wants_coach": coach});
-  this._protoBufHeader.msg = Dota2.k_EMsgGCPartyMemberSetCoach;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    var payload = new Dota2.schema.CMsgDOTAPartyMemberSetCoach({
+        "wants_coach": coach
+    });
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCPartyMemberSetCoach, payload);
 };
 
 Dota2.Dota2Client.prototype.inviteToParty = function(steam_id) {
-  steam_id = steam_id || null;
+    steam_id = steam_id || null;
+    if (steam_id == null) {
+        if (this.debug) util.log("Steam ID required to create a party invite.");
+        return null;
+    }
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (steam_id == null) {
-    if (this.debug) util.log("Steam ID required to create a party invite.");
-    return null;
-  }
-
-  if (this.debug) util.log("Inviting "+steam_id+" to a party.");
-  // todo: set client version here?
-  var payload = new Dota2.schema.CMsgInviteToParty({
-    "steam_id": steam_id
-  });
-  this._protoBufHeader.msg = Dota2.EGCBaseMsg.k_EMsgGCInviteToParty;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    if (this.debug) util.log("Inviting " + steam_id + " to a party.");
+    // todo: set client version here?
+    var payload = new Dota2.schema.CMsgInviteToParty({
+        "steam_id": steam_id
+    });
+    this.sendToGC(Dota2.schema.EGCBaseMsg.k_EMsgGCInviteToParty, payload);
 };
 
 Dota2.Dota2Client.prototype.kickFromParty = function(steam_id) {
-  steam_id = steam_id || null;
+    steam_id = steam_id || null;
+    if (steam_id == null) {
+        if (this.debug) util.log("Steam ID required to kick from the party.");
+        return null;
+    }
 
-  if (!this._gcReady) {
-    if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-    return null;
-  }
-
-  if (steam_id == null) {
-    if (this.debug) util.log("Steam ID required to kick from the party.");
-    return null;
-  }
-
-  if (this.debug) util.log("Kicking "+steam_id+" from the party.");
-  // todo: set client version here?
-  var payload = new Dota2.schema.CMsgKickFromParty({
-    "steam_id": steam_id
-  });
-  this._protoBufHeader.msg = Dota2.EGCBaseMsg.k_EMsgGCKickFromParty;
-  this._gc.send(this._protoBufHeader,
-                payload.toBuffer()
-  );
+    if (this.debug) util.log("Kicking " + steam_id + " from the party.");
+    // todo: set client version here?
+    var payload = new Dota2.schema.CMsgKickFromParty({
+        "steam_id": steam_id
+    });
+    this.sendToGC(Dota2.schema.EGCBaseMsg.k_EMsgGCKickFromParty, payload);
 };

--- a/handlers/sourcetv.js
+++ b/handlers/sourcetv.js
@@ -4,53 +4,51 @@ var Dota2 = require("../index"),
 
 // Methods
 
-Dota2.Dota2Client.prototype.requestSourceTVGames = function(filter_options, callback) {
-    callback = callback || null;
+Dota2.Dota2Client.prototype.requestSourceTVGames = function(filter_options) {
+    // Unfortunately this does not seem to support callbacks
+    filter_options = filter_options || null;
     var _self = this;
-    /* Sends a message to the Game Coordinator requesting `accountId`'s profile data.  Listen for `profileData` event for Game Coordinator's response. */
-    if (!this._gcReady) {
-        if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
-        return null;
-    }
-    
-    if (this.debug) util.log("Sending find SourceTV games request");
-    
-    /* Using default params and merging with filter_options, note: numGames is ignored from GC and > 6 causes no response at all */
-    var payload = new Dota2.schema.CMsgFindSourceTVGames(merge({
-        "searchKey": '',
-        "start": 0,
-        "numGames": 6,
-        "leagueid": 0,
-        "heroid": 0,
-        "teamGame": false,
-        "customGameId": 0,
-    },filter_options));
-    this._protoBufHeader.msg = Dota2.schema.EDOTAGCMsg.k_EMsgGCFindSourceTVGames;
-    this._gc.send(this._protoBufHeader,
-                payload.toBuffer(),
-                function (header, body) {
-                  onSourceTVGamesResponse.call(_self, body, callback);
-                }
-    );
+    if (this.debug) util.log("Sending SourceTV games request");
+
+    var payload = new Dota2.schema.CMsgClientToGCFindTopSourceTVGames(merge({
+        "search_key": '',     // I don't know what's supposed to go here, everything i've tried fails
+        "league_id": 0,       // Presumably used for searching for live games in a tourney
+        "hero_id": 0,         // Same as the old one, hero filter using id number
+        "start_game": 0,      // Number of pages sent, only values in [0, 10, 20, ... 90] are valid, and yield [1,2,3 ... 10] responses
+        "game_list_index": 0, // I think this may be some sort of version number
+        "lobby_ids": [],      // Used for getting player specific games, still don't know where the lobbyids come from though
+    }, filter_options));
+
+    this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgClientToGCFindTopSourceTVGames, payload);
 };
 
 // Handlers
 
 var handlers = Dota2.Dota2Client.prototype._handlers;
 
-var onSourceTVGamesResponse = function onSourceTVGamesResponse(message, callback) {
-    callback = callback || null;
+var onSourceTVGamesResponse = function onSourceTVGamesResponse(message) {
+    var sourceTVGamesResponse = Dota2.schema.CMsgGCToClientFindTopSourceTVGamesResponse.decode(message);
 
-    var sourceTVGamesResponse = Dota2.schema.CMsgSourceTVGamesResponse.decode(message);
-
-    if (typeof sourceTVGamesResponse.games !== "undefined" && sourceTVGamesResponse.games.length > 0) {
+    if (sourceTVGamesResponse.start_game !== null) {
         if (this.debug) util.log("Received SourceTV games data");
-        this.emit("sourceTVGamesData", sourceTVGamesResponse.num_total_games, sourceTVGamesResponse.games);
-        if (callback) callback(sourceTVGamesResponse);
-    }
-    else {
-        if (this.debug) util.log("Received a bad SourceTV games response");
-        if (callback) callback(sourceTVGamesResponse.result, sourceTVGamesResponse);
+        this.emit("sourceTVGamesData", sourceTVGamesResponse);
+    } else {
+        if (this.debug) util.log("Received a bad new SourceTV games response");
+        this.emit("sourceTVGamesData", null);
+        /*
+
+        A "bad" response will look like this.
+        Any of these values should be ok to check for, except maybe game_list
+
+        { search_key: null,
+          league_id: null,
+          hero_id: null,
+          start_game: null,
+          num_games: 0,
+          game_list_index: null,
+          game_list: [],
+          specific_games: null }
+        */
     }
 };
-handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCSourceTVGamesResponse] = onSourceTVGamesResponse;
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCToClientFindTopSourceTVGamesResponse] = onSourceTVGamesResponse;

--- a/handlers/team.js
+++ b/handlers/team.js
@@ -1,0 +1,133 @@
+var Dota2 = require("../index"),
+    util = require("util");
+
+Dota2.Dota2Client.prototype.requestMyTeams = function requestMyTeams(callback) {
+    // Request the team data for the currently logged in user
+    callback = callback || null;
+    var _self = this;
+    if (!this._gcReady) {
+        if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
+        return null;
+    }
+
+    if (this.debug) util.log("Requesting my own team data");
+    var payload = new Dota2.schema.CMsgDOTARequestTeamData({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestTeamData,
+                    payload, 
+                    onTeamDataResponse, callback);
+}
+
+Dota2.Dota2Client.prototype.requestTeamProfile = function requestTeamProfile(team_id, callback) {
+    // Request the profile of a given team
+    callback = callback || null;
+    var _self = this;
+
+    if (this.debug) util.log("Sending team profile request");
+    var payload = new Dota2.schema.CMsgDOTATeamProfileRequest({
+        "team_id": team_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCTeamProfileRequest, 
+                    payload, 
+                    onTeamProfileResponse, callback);
+}
+
+Dota2.Dota2Client.prototype.requestTeamIDByName = function requestTeamIDByName(team_name, callback) {
+    // Request the ID of a given team
+    callback = callback || null;
+    var _self = this;
+
+    if (this.debug) util.log("Sending team ID by name request");
+    var payload = new Dota2.schema.CMsgDOTATeamIDByNameRequest({
+        "name": team_name
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCTeamIDByNameRequest, 
+                    payload, 
+                    onTeamIDByNameResponse, callback);
+}
+
+Dota2.Dota2Client.prototype.requestTeamMemberProfile = function requestTeamMemberProfile(steam_id, callback) {
+    // Request the profile of a given team member
+    callback = callback || null;
+    var _self = this;
+
+    if (this.debug) util.log("Sending team member profile request");
+    var payload = new Dota2.schema.CMsgDOTATeamMemberProfileRequest({
+        "steam_id": steam_id
+    });
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCTeamMemberProfileRequest,
+                    payload, 
+                    onTeamProfileResponse, callback);
+}
+
+Dota2.Dota2Client.prototype.requestProTeamList = function requestProTeamList(callback) {
+    // Request the list of pro teams
+    callback = callback || null;
+    var _self = this;
+
+    if (this.debug) util.log("Requesting list of pro teams");
+    var payload = new Dota2.schema.CMsgDOTAProTeamListRequest({});
+    this.sendToGC(  Dota2.schema.EDOTAGCMsg.k_EMsgGCProTeamListRequest, 
+                    payload, 
+                    onProTeamListResponse, callback);
+}
+
+
+var handlers = Dota2.Dota2Client.prototype._handlers;
+
+var onTeamDataResponse = function onTeamDataResponse(message, callback) {
+    var teamDataResponse = Dota2.schema.CMsgDOTARequestTeamDataResponse.decode(message);
+    
+    if (teamDataResponse.result === Dota2.schema.CMsgDOTARequestTeamDataResponse.Result.SUCCESS) {
+        if (this.debug) util.log("Received my teams response " + JSON.stringify(teamDataResponse));
+        this.emit("teamData", teamDataResponse.data);
+        if (callback) callback(null, teamDataResponse);
+    } else {
+        if (this.debug) util.log("Received a bad my teams response " + JSON.stringify(teamDataResponse));
+        if (callback) callback(teamDataResponse.result, teamDataResponse);
+    }
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCRequestTeamDataResponse] = onTeamDataResponse;
+
+var onTeamProfileResponse = function onTeamProfileResponse(message, callback) {
+    var teamProfileResponse = Dota2.schema.CMsgDOTATeamProfileResponse.decode(message);
+    
+    if (teamProfileResponse.eresult === 1) {
+        if (this.debug) util.log("Received team profile response " + JSON.stringify(teamProfileResponse));
+        this.emit("teamProfile", teamProfileResponse.team.team_id, teamProfileResponse.team);
+        if (callback) callback(null, teamProfileResponse);
+    } else {
+        if (this.debug) util.log("Couldn't find team profile " + JSON.stringify(teamProfileResponse));
+        if (callback) callback(teamProfileResponse.eresult, teamProfileResponse);
+    }
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCTeamProfileResponse] = onTeamProfileResponse;
+
+var onTeamIDByNameResponse = function onTeamIDByNameResponse(message, callback) {
+    var teamID = Dota2.schema.CMsgDOTATeamIDByNameResponse.decode(message);
+    
+    if (teamID.eresult === 1) {
+        if (this.debug) util.log("Received team ID " + teamID.team_id);
+        this.emit("teamID", teamID.team_id);
+        if (callback) callback(null, teamID);
+    } else {
+        if (this.debug) util.log("Couldn't find team ID " + JSON.stringify(teamID));
+        this.emit("teamID", null);
+        if (callback) callback(teamID.eresult, teamID);
+    }
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCTeamIDByNameResponse] = onTeamIDByNameResponse;
+
+var onProTeamListResponse = function onProTeamListResponse(message, callback) {
+    var teams = Dota2.schema.CMsgDOTAProTeamListResponse.decode(message);
+    
+    if (teams.eresult === 1) {
+        if (this.debug) util.log("Received pro team list");
+        this.emit("proTeamListData", teams.teams);
+        if (callback) callback(null, teams);
+    } else {
+        if (this.debug) util.log("Bad pro team list response " + JSON.stringify(teams));
+        this.emit("proTeamListData", null);
+        if (callback) callback(teams.eresult, teams);
+    }
+};
+handlers[Dota2.schema.EDOTAGCMsg.k_EMsgGCProTeamListResponse] = onProTeamListResponse;

--- a/index.js
+++ b/index.js
@@ -11,9 +11,9 @@ var EventEmitter = require('events').EventEmitter,
     Dota2 = exports;
 
 var builder = ProtoBuf.newBuilder();
-var folder = fs.readdirSync(__dirname+'/proto');
-folder.forEach(function(f){
-    ProtoBuf.loadProtoFile(__dirname+'/proto/'+f, builder);
+var folder = fs.readdirSync(__dirname + '/proto');
+folder.forEach(function(f) {
+    ProtoBuf.loadProtoFile(__dirname + '/proto/' + f, builder);
 });
 Dota2.schema = builder.build();
 Dota2.ServerRegion = {
@@ -33,131 +33,141 @@ Dota2.ServerRegion = {
 };
 
 var Dota2Client = function Dota2Client(steamClient, debug, debugMore) {
-  EventEmitter.call(this);
+    EventEmitter.call(this);
 
-  this.debug = debug || false;
-  this.debugMore = debugMore || false;
+    this.debug = debug || false;
+    this.debugMore = debugMore || false;
 
-  var steamUser = new steam.SteamUser(steamClient);
-  this._user = steamUser;
-  this._client = steamClient;
-  this._gc = new steam.SteamGameCoordinator(steamClient, DOTA_APP_ID);
-  this._appid = DOTA_APP_ID;
-  this.chatChannels = []; // Map channel names to channel data.
-  this._gcReady = false;
-  this._gcClientHelloIntervalId = null;
-  this._gcConnectionStatus = Dota2.schema.GCConnectionStatus.GCConnectionStatus_NO_SESSION;
-  // This should probably be reworked to use a CMsgProtoBufHeader object
-  this._protoBufHeader = {
-    "msg":    "",
-    "proto":  {
-      "client_steam_id": this._client.steamID,
-      "source_app_id":  this._appid
-    }
-  };
+    var steamUser = new steam.SteamUser(steamClient);
+    this._user = steamUser;
+    this._client = steamClient;
+    this._gc = new steam.SteamGameCoordinator(steamClient, DOTA_APP_ID);
+    this._appid = DOTA_APP_ID;
+    this.chatChannels = []; // Map channel names to channel data.
+    this._gcReady = false;
+    this._gcClientHelloIntervalId = null;
+    this._gcConnectionStatus = Dota2.schema.GCConnectionStatus.GCConnectionStatus_NO_SESSION;
+    // This should probably be reworked to use a CMsgProtoBufHeader object
+    this._protoBufHeader = {
+        "msg": "",
+        "proto": {
+            "client_steam_id": this._client.steamID,
+            "source_app_id": this._appid
+        }
+    };
 
-  var self = this;
-  this._gc.on("message", function fromGC(header, body, callback) {
-    /* Routes messages from Game Coordinator to their handlers. */
-    callback = callback || null;
+    var self = this;
+    this._gc.on("message", function fromGC(header, body, callback) {
+        /* Routes messages from Game Coordinator to their handlers. */
+        callback = callback || null;
 
-    var kMsg = header.msg;
-    if (self.debugMore) util.log("Dota2 fromGC: " + kMsg);  // TODO:  Turn type-protoMask into key name.
+        var kMsg = header.msg;
+        if (self.debugMore) util.log("Dota2 fromGC: " + kMsg); // TODO:  Turn type-protoMask into key name.
 
-    if (kMsg in self._handlers) {
-      if (callback) {
-        self._handlers[kMsg].call(self, body, callback);
-      }
-      else {
-        self._handlers[kMsg].call(self, body);
-      }
-    }
-    else {
-      self.emit("unhandled", kMsg);
-    }
-  });
+        if (kMsg in self._handlers) {
+            if (callback) {
+                self._handlers[kMsg].call(self, body, callback);
+            } else {
+                self._handlers[kMsg].call(self, body);
+            }
+        } else {
+            self.emit("unhandled", kMsg);
+        }
+    });
 
-  this._sendClientHello = function() {
-    if(self._gcReady)
-    {
-      if(self._gcClientHelloIntervalId)
-      {
-        clearInterval(self._gcClientHelloIntervalId);
-        self._gcClientHelloIntervalId = null;
-      }
-      return;
-    }
-    if(self._gcClientHelloCount > 10)
-    {
-      if(self.debug) util.log("ClientHello has taken longer than 30 seconds! Reporting timeout...");
-      self._gcClientHelloCount = 0;
-      self.emit("hellotimeout");
-    }
+    this._sendClientHello = function() {
+        if (self._gcReady) {
+            if (self._gcClientHelloIntervalId) {
+                clearInterval(self._gcClientHelloIntervalId);
+                self._gcClientHelloIntervalId = null;
+            }
+            return;
+        }
+        if (self._gcClientHelloCount > 10) {
+            if (self.debug) util.log("ClientHello has taken longer than 30 seconds! Reporting timeout...");
+            self._gcClientHelloCount = 0;
+            self.emit("hellotimeout");
+        }
 
-    if (self.debug) util.log("Sending ClientHello");
-    if (!self._gc) {
-      util.log("Where the fuck is _gc?");
-    }
-    else {
-      self._protoBufHeader.msg = Dota2.schema.EGCBaseClientMsg.k_EMsgGCClientHello;
-      var payload = new Dota2.schema.CMsgClientHello({});
-      payload.engine = 1;
-      payload.secret_key= "";
-      payload.client_session_need= 104;
-      self._gc.send(
-        self._protoBufHeader,
-        payload.toBuffer()
-      );
-    }
+        if (self.debug) util.log("Sending ClientHello");
+        if (!self._gc) {
+            util.log("Where the fuck is _gc?");
+        } else {
+            self._protoBufHeader.msg = Dota2.schema.EGCBaseClientMsg.k_EMsgGCClientHello;
+            var payload = new Dota2.schema.CMsgClientHello({});
+            payload.engine = 1;
+            payload.secret_key = "";
+            payload.client_session_need = 104;
+            self._gc.send(
+                self._protoBufHeader,
+                payload.toBuffer()
+            );
+        }
 
-    self._gcClientHelloCount++;
-  };
+        self._gcClientHelloCount++;
+    };
 };
 util.inherits(Dota2Client, EventEmitter);
 
 // Expose enums
 Dota2Client.prototype.ServerRegion = Dota2.ServerRegion;
-Dota2Client.prototype.ToAccountID = function(accid){
-  return new bignumber(accid).minus('76561197960265728')-0;
+Dota2Client.prototype.ToAccountID = function(accid) {
+    return new bignumber(accid).minus('76561197960265728') - 0;
 };
-Dota2Client.prototype.ToSteamID = function(accid){
-  return new bignumber(accid).plus('76561197960265728')+"";
+Dota2Client.prototype.ToSteamID = function(accid) {
+    return new bignumber(accid).plus('76561197960265728') + "";
 };
 
 // Methods
 Dota2Client.prototype.launch = function() {
-  /* Reports to Steam that we are running Dota 2. Initiates communication with GC with EMsgGCClientHello */
-  if (this.debug) util.log("Launching Dota 2");
-  this.AccountID = this.ToAccountID(this._client.steamID);
-  this.Party = null;
-  this.Lobby = null;
-  this.PartyInvite = null;
-  this._user.gamesPlayed([{"game_id": this._appid}]);
+    /* Reports to Steam that we are running Dota 2. Initiates communication with GC with EMsgGCClientHello */
+    if (this.debug) util.log("Launching Dota 2");
+    this.AccountID = this.ToAccountID(this._client.steamID);
+    this.Party = null;
+    this.Lobby = null;
+    this.PartyInvite = null;
+    this._user.gamesPlayed([{
+        "game_id": this._appid
+    }]);
 
-  // Keep knocking on the GCs door until it accepts us.
-  // This is very bad practice and quite trackable.
-  // The real client tends to send only one of these.
-  // Really we should just send one when the connection status is GC online
-  this._gcClientHelloCount = 0;
-  this._gcClientHelloIntervalId = setInterval(this._sendClientHello, 6000);
+    // Keep knocking on the GCs door until it accepts us.
+    // This is very bad practice and quite trackable.
+    // The real client tends to send only one of these.
+    // Really we should just send one when the connection status is GC online
+    this._gcClientHelloCount = 0;
+    this._gcClientHelloIntervalId = setInterval(this._sendClientHello, 6000);
 
-  //Also immediately send clienthello
-  setTimeout(this._sendClientHello, 1000);
+    //Also immediately send clienthello
+    setTimeout(this._sendClientHello, 1000);
 };
 
 Dota2Client.prototype.exit = function() {
-  /* Reports to Steam we are not running any apps. */
-  if (this.debug) util.log("Exiting Dota 2");
+    /* Reports to Steam we are not running any apps. */
+    if (this.debug) util.log("Exiting Dota 2");
 
-  /* stop knocking if exit comes before ready event */
-  if (this._gcClientHelloIntervalId) {
-      clearInterval(this._gcClientHelloIntervalId);
-      this._gcClientHelloIntervalId = null;
-  }
-  this._gcReady = false;
+    /* stop knocking if exit comes before ready event */
+    if (this._gcClientHelloIntervalId) {
+        clearInterval(this._gcClientHelloIntervalId);
+        this._gcClientHelloIntervalId = null;
+    }
+    this._gcReady = false;
 
-  if(this._user.loggedOn) this._user.gamesPlayed([]);
+    if (this._client.loggedOn) this._user.gamesPlayed([]);
 };
+
+Dota2Client.prototype.sendToGC = function(type, payload, handler, callback) {
+    var self = this;
+    if (!this._gcReady) {
+        if (this.debug) util.log("GC not ready, please listen for the 'ready' event.");
+        if (callback) callback(-1, null);                   // notify user that something went wrong
+        return null;
+    }
+    this._protoBufHeader.msg = type;
+    this._gc.send(this._protoBufHeader,                     // protobuf header, same for all messages
+                  payload.toBuffer(),                       // payload of the message
+                  Dota2._convertCallback.call(self, handler, callback) // let handler treat callback so events are triggered
+    );
+}
 
 
 // Handlers
@@ -165,54 +175,54 @@ Dota2Client.prototype.exit = function() {
 var handlers = Dota2Client.prototype._handlers = {};
 
 handlers[Dota2.schema.EGCBaseClientMsg.k_EMsgGCClientWelcome] = function clientWelcomeHandler(message) {
-  /* Response to our k_EMsgGCClientHello, now we can execute other GC commands. */
+    /* Response to our k_EMsgGCClientHello, now we can execute other GC commands. */
 
-  // Only execute if _gcClientHelloIntervalID, otherwise it's already been handled (and we don't want to emit multiple 'ready');
-  if (this._gcClientHelloIntervalId) {
-    clearInterval(this._gcClientHelloIntervalId);
-    this._gcClientHelloIntervalId = null;
-  }
+    // Only execute if _gcClientHelloIntervalID, otherwise it's already been handled (and we don't want to emit multiple 'ready');
+    if (this._gcClientHelloIntervalId) {
+        clearInterval(this._gcClientHelloIntervalId);
+        this._gcClientHelloIntervalId = null;
+    }
 
-  if (this.debug) util.log("Received client welcome.");
+    if (this.debug) util.log("Received client welcome.");
 
-  // Parse any caches
-  this._gcReady = true;
-  //this._handleWelcomeCaches(message);
-  this.emit("ready");
+    // Parse any caches
+    this._gcReady = true;
+    //this._handleWelcomeCaches(message);
+    this.emit("ready");
 };
 
 handlers[Dota2.schema.EGCBaseClientMsg.k_EMsgGCClientConnectionStatus] = function gcClientConnectionStatus(message) {
-  /* Catch and handle changes in connection status, cuz reasons u know. */
+    /* Catch and handle changes in connection status, cuz reasons u know. */
 
-  var status = Dota2.schema.CMsgConnectionStatus.decode(message).status;
-  if(status) this._gcConnectionStatus = status;
+    var status = Dota2.schema.CMsgConnectionStatus.decode(message).status;
+    if (status) this._gcConnectionStatus = status;
 
-  switch (status) {
-    case Dota2.schema.GCConnectionStatus.GCConnectionStatus_HAVE_SESSION:
-      if (this.debug) util.log("GC Connection Status regained.");
+    switch (status) {
+        case Dota2.schema.GCConnectionStatus.GCConnectionStatus_HAVE_SESSION:
+            if (this.debug) util.log("GC Connection Status regained.");
 
-      // Only execute if _gcClientHelloIntervalID, otherwise it's already been handled (and we don't want to emit multiple 'ready');
-      if (this._gcClientHelloIntervalId) {
-        clearInterval(this._gcClientHelloIntervalId);
-        this._gcClientHelloIntervalId = null;
+            // Only execute if _gcClientHelloIntervalID, otherwise it's already been handled (and we don't want to emit multiple 'ready');
+            if (this._gcClientHelloIntervalId) {
+                clearInterval(this._gcClientHelloIntervalId);
+                this._gcClientHelloIntervalId = null;
 
-        this._gcReady = true;
-        this.emit("ready");
-      }
-      break;
+                this._gcReady = true;
+                this.emit("ready");
+            }
+            break;
 
-    default:
-      if (this.debug) util.log("GC Connection Status unreliable - " + status);
+        default:
+            if (this.debug) util.log("GC Connection Status unreliable - " + status);
 
-      // Only execute if !_gcClientHelloIntervalID, otherwise it's already been handled (and we don't want to emit multiple 'unready');
-      if (!this._gcClientHelloIntervalId) {
-        this._gcClientHelloIntervalId = setInterval(this._sendClientHello, 5000); // Continually try regain GC session
+            // Only execute if !_gcClientHelloIntervalID, otherwise it's already been handled (and we don't want to emit multiple 'unready');
+            if (!this._gcClientHelloIntervalId) {
+                this._gcClientHelloIntervalId = setInterval(this._sendClientHello, 5000); // Continually try regain GC session
 
-        this._gcReady = false;
-        this.emit("unready");
-      }
-      break;
-  }
+                this._gcReady = false;
+                this.emit("unready");
+            }
+            break;
+    }
 };
 
 Dota2.Dota2Client = Dota2Client;
@@ -228,3 +238,5 @@ require("./handlers/lobbies");
 require("./handlers/parties");
 require("./handlers/leagues");
 require("./handlers/sourcetv");
+require("./handlers/team");
+require("./handlers/custom");

--- a/package.json
+++ b/package.json
@@ -1,16 +1,15 @@
 {
   "name": "dota2",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "dependencies": {
-    "bignumber.js": "2.0.7",
+    "bignumber.js": "^2.1.0",
     "deferred": "^0.7.2",
     "merge": "^1.2.0",
-    "protobufjs": "^4.0.0",
+    "protobufjs": "^5.0.0",
     "steam": "^1.2.0"
   },
   "scripts": {
-    "update": "bash update_proto.sh",
-    "test": "mocha"
+    "update": "bash update_proto.sh"
   },
   "readmeFilename": "README.md",
   "description": "A node-steam plugin for Dota 2.",
@@ -24,9 +23,5 @@
     "valve",
     "dota"
   ],
-  "license": "MIT",
-  "devDependencies": {
-    "mocha": "^2.3.3",
-    "should": "^7.1.1"
-  }
+  "license": "MIT"
 }

--- a/proto/base_gcmessages.proto
+++ b/proto/base_gcmessages.proto
@@ -100,10 +100,6 @@ message CMsgPartyInviteResponse {
 	optional uint64 party_id = 1;
 	optional bool accept = 2;
 	optional uint32 client_version = 3;
-	optional uint32 team_id = 4;
-	optional bool as_coach = 5;
-	optional uint32 game_language_enum = 6;
-	optional string game_language_name = 7;
 	optional .CMsgClientPingData ping_data = 8;
 }
 
@@ -111,8 +107,6 @@ message CMsgLobbyInviteResponse {
 	optional fixed64 lobby_id = 1;
 	optional bool accept = 2;
 	optional uint32 client_version = 3;
-	optional uint32 game_language_enum = 4;
-	optional string game_language_name = 5;
 	optional fixed64 custom_game_crc = 6;
 	optional fixed32 custom_game_timestamp = 7;
 }
@@ -341,22 +335,6 @@ message CSOSelectedItemPreset {
 	optional uint32 account_id = 1 [(key_field) = true];
 	optional uint32 class_id = 2 [(key_field) = true];
 	optional uint32 preset_id = 3;
-}
-
-message CMsgGCReportAbuse {
-	optional fixed64 target_steam_id = 1;
-	optional string description = 4;
-	optional uint64 gid = 5;
-	optional uint32 abuse_type = 2;
-	optional uint32 content_type = 3;
-	optional fixed32 target_game_server_ip = 6;
-	optional uint32 target_game_server_port = 7;
-}
-
-message CMsgGCReportAbuseResponse {
-	optional fixed64 target_steam_id = 1;
-	optional uint32 result = 2;
-	optional string error_message = 3;
 }
 
 message CMsgGCNameItemNotification {

--- a/proto/dota_gcmessages_client.proto
+++ b/proto/dota_gcmessages_client.proto
@@ -7,6 +7,12 @@ import "base_gcmessages.proto";
 option optimize_for = SPEED;
 option cc_generic_services = false;
 
+enum EMatchGroupServerStatus {
+	k_EMatchGroupServerStatus_OK = 0;
+	k_EMatchGroupServerStatus_LimitedAvailability = 1;
+	k_EMatchGroupServerStatus_Offline = 2;
+}
+
 enum DOTA_WatchReplayType {
 	DOTA_WATCH_REPLAY_NORMAL = 0;
 	DOTA_WATCH_REPLAY_HIGHLIGHTS = 1;
@@ -244,6 +250,10 @@ message CMsgPracticeLobbySetDetails {
 	optional uint32 league_game_id = 36;
 	optional fixed32 custom_game_timestamp = 37;
 	optional uint64 previous_match_override = 38;
+	optional uint32 league_selection_priority_team = 39;
+	optional .SelectionPriorityType league_selection_priority_choice = 40 [default = UNDEFINED];
+	optional .SelectionPriorityType league_non_selection_priority_choice = 41 [default = UNDEFINED];
+	optional .LobbyDotaPauseSetting pause_setting = 42 [default = LobbyDotaPauseSetting_Unlimited];
 }
 
 message CMsgPracticeLobbyCreate {
@@ -1118,12 +1128,15 @@ message CMsgDOTAChatMessage {
 	optional uint64 share_lobby_id = 19;
 	optional uint64 share_lobby_custom_game_id = 20;
 	optional string share_lobby_passkey = 21;
+	optional uint32 private_chat_channel_id = 22;
+	optional uint32 status = 23;
 }
 
 message CMsgDOTAChatMember {
 	optional fixed64 steam_id = 1;
 	optional string persona_name = 2;
 	optional uint32 channel_user_id = 3;
+	optional uint32 status = 4;
 }
 
 message CMsgDOTAJoinChatChannelResponse {
@@ -1138,6 +1151,10 @@ message CMsgDOTAJoinChatChannelResponse {
 		CHANNEL_FULL_OVERFLOWED = 7;
 		FAILED_TO_ADD_USER = 8;
 		CHANNEL_TYPE_DISABLED = 9;
+		PRIVATE_CHAT_CREATE_FAILED = 10;
+		PRIVATE_CHAT_NO_PERMISSION = 11;
+		PRIVATE_CHAT_CREATE_LOCK_FAILED = 12;
+		PRIVATE_CHAT_KICKED = 13;
 	}
 
 	optional uint32 response = 1;
@@ -1149,6 +1166,7 @@ message CMsgDOTAJoinChatChannelResponse {
 	optional .CMsgDOTAJoinChatChannelResponse.Result result = 7 [default = JOIN_SUCCESS];
 	optional bool gc_initiated_join = 8;
 	optional uint32 channel_user_id = 9;
+	optional string welcome_message = 10;
 }
 
 message CMsgDOTAChatChannelFullUpdate {
@@ -1161,6 +1179,7 @@ message CMsgDOTAOtherJoinedChatChannel {
 	optional string persona_name = 2;
 	optional fixed64 steam_id = 3;
 	optional uint32 channel_user_id = 4;
+	optional uint32 status = 5;
 }
 
 message CMsgDOTAOtherLeftChatChannel {
@@ -1174,6 +1193,7 @@ message CMsgDOTAChatChannelMemberUpdate {
 		optional fixed64 steam_id = 1;
 		optional string persona_name = 2;
 		optional uint32 channel_user_id = 3;
+		optional uint32 status = 4;
 	}
 
 	optional fixed64 channel_id = 1;
@@ -1203,6 +1223,7 @@ message CMsgDOTAChatGetUserListResponse {
 		optional fixed64 steam_id = 1;
 		optional string persona_name = 2;
 		optional uint32 channel_user_id = 3;
+		optional uint32 status = 4;
 	}
 
 	optional fixed64 channel_id = 1;
@@ -1534,6 +1555,7 @@ message CMsgWatchGame {
 	optional uint32 client_version = 2;
 	optional fixed64 watch_server_steamid = 3;
 	optional uint64 lobby_id = 4;
+	repeated uint32 regions = 5;
 }
 
 message CMsgCancelWatchGame {
@@ -1696,6 +1718,7 @@ message CMsgDOTAWelcome {
 	optional bool is_perfect_world_test_account = 24;
 	repeated .EEvent active_events = 25;
 	repeated .CMsgDOTAWelcome.CExtraMsg extra_messages = 26;
+	optional uint64 minimum_recent_item_id = 27;
 }
 
 message CSODOTAGameHeroFavorites {
@@ -1753,6 +1776,12 @@ message CStaticLeagueData {
 	optional uint32 sort_order = 12;
 	optional uint32 tier = 13;
 	optional uint32 amateur_region = 14;
+	optional string organizer = 15;
+	optional uint32 start_date = 16;
+	optional uint32 end_date = 17;
+	optional string location = 18;
+	optional string inventory_image = 19;
+	optional string square_image = 20;
 }
 
 message CLeagueData {
@@ -1898,29 +1927,27 @@ message CMsgDOTALeaguesInMonthResponse {
 	repeated .CMsgDOTALeague leagues = 4;
 }
 
-message CMsgSockAddrList {
+message CMsgMatchGroupServerStatus {
 	repeated fixed32 ip = 1 [packed = true];
 	repeated uint32 port = 2 [packed = true];
+	optional sint32 auto_region_select_ping_penalty = 3;
+	optional .EMatchGroupServerStatus status = 4 [default = k_EMatchGroupServerStatus_OK];
 }
 
 message CMsgMatchmakingGroupServerSample {
-	repeated .CMsgSockAddrList servers_by_group = 5;
-	optional uint32 servers_to_ping = 2;
-	optional uint32 reply_odds = 3;
-	optional uint32 reply_detailed_odds = 4;
+	repeated .CMsgMatchGroupServerStatus match_groups = 5;
+	optional uint32 legacy_servers_to_ping = 2;
 }
 
 message CMsgDOTAMatchmakingStatsRequest {
 }
 
 message CMsgDOTAMatchmakingStatsResponse {
+	optional uint32 matchgroups_version = 1;
 	repeated uint32 searching_players_by_group = 2;
 	repeated uint32 searching_players_by_group_source2 = 7;
-	optional uint32 disabled_groups = 3;
-	optional uint32 disabled_groups_source2 = 8;
-	optional .CMsgMatchmakingGroupServerSample gameserver_sample = 4;
 	optional .CMsgMatchmakingGroupServerSample gameserver_sample_source2 = 6;
-	optional bool maintenance_alerts = 5;
+	optional uint32 legacy_disabled_groups_source2 = 8;
 }
 
 message CMsgDOTASetMatchHistoryAccess {
@@ -2028,6 +2055,18 @@ message CMsgGCGetHeroStandingsResponse {
 		optional uint32 hero_id = 1;
 		optional uint32 wins = 2;
 		optional uint32 losses = 3;
+		optional uint32 win_streak = 4;
+		optional uint32 best_win_streak = 5;
+		optional float avg_kills = 6;
+		optional float avg_deaths = 7;
+		optional float avg_assists = 8;
+		optional float avg_gpm = 9;
+		optional float avg_xpm = 10;
+		optional uint32 best_kills = 11;
+		optional uint32 best_assists = 12;
+		optional uint32 best_gpm = 13;
+		optional uint32 best_xpm = 14;
+		optional float performance = 15;
 	}
 
 	repeated .CMsgGCGetHeroStandingsResponse.Hero standings = 1;
@@ -2480,22 +2519,6 @@ message CMsgGCToClientEventStatusChanged {
 	repeated .EEvent active_events = 1;
 }
 
-message CMsgClientToGCExchangeItemsForOffering {
-	repeated uint64 item_ids = 1;
-	optional uint32 recycle_id = 2;
-}
-
-message CMsgClientToGCExchangeItemsForOfferingResponse {
-	enum EResponse {
-		eResponse_Success = 0;
-		eResponse_OfferingDisabled = 1;
-		eResponse_InvalidItems = 2;
-		eResponse_InternalError = 3;
-	}
-
-	optional .CMsgClientToGCExchangeItemsForOfferingResponse.EResponse response = 1 [default = eResponse_Success];
-}
-
 message CMsgClientToGCPlayerStatsRequest {
 	optional uint32 account_id = 1;
 }
@@ -2705,6 +2728,7 @@ message CMsgClientToGCGetLeagueSeriesResponse {
 			optional string team_name = 2;
 			optional string team_tag = 3;
 			optional uint32 team_score = 4;
+			optional uint32 team_wins = 5;
 		}
 
 		optional uint32 series_id = 1;
@@ -2714,6 +2738,7 @@ message CMsgClientToGCGetLeagueSeriesResponse {
 		optional string phase_name = 5;
 		optional uint32 start_time = 6;
 		optional uint32 after_series_id = 7;
+		optional uint32 num_completed_games = 8;
 	}
 
 	repeated .CMsgClientToGCGetLeagueSeriesResponse.Series series = 1;
@@ -2749,5 +2774,149 @@ message CMsgClientToGCCreateStaticRecipeResponse {
 	}
 
 	optional .CMsgClientToGCCreateStaticRecipeResponse.EResponse response = 1 [default = eResponse_Success];
+}
+
+message CDOTAReplayDownloadInfo {
+	message Highlight {
+		optional uint32 timestamp = 1;
+		optional string description = 2;
+	}
+
+	optional .CMsgDOTAMatchMinimal match = 1;
+	optional string title = 2;
+	optional string description = 3;
+	optional uint32 size = 4;
+	repeated string tags = 5;
+	optional bool exists_on_disk = 6;
+}
+
+message CDOTABroadcasterInfo {
+	optional uint32 account_id = 1;
+	optional fixed64 server_steam_id = 2;
+	optional bool live = 3;
+	optional string team_name_radiant = 4;
+	optional string team_name_dire = 5;
+	optional string stage_name = 6;
+	optional uint32 series_game = 7;
+	optional uint32 series_type = 8;
+	optional uint32 upcoming_broadcast_timestamp = 9;
+	optional bool allow_live_video = 10;
+}
+
+message CMsgClientToGCH264Unsupported {
+}
+
+message CMsgClientToGCRequestH264Support {
+}
+
+message CMsgClientToGCGetQuestProgress {
+	repeated uint32 quest_ids = 1;
+}
+
+message CMsgClientToGCGetQuestProgressResponse {
+	message Challenge {
+		optional uint32 challenge_id = 1;
+		optional uint32 time_completed = 2;
+		optional uint32 attempts = 3;
+		optional uint32 hero_id = 4;
+	}
+
+	message Quest {
+		optional uint32 quest_id = 1;
+		repeated .CMsgClientToGCGetQuestProgressResponse.Challenge completed_challenges = 2;
+	}
+
+	optional bool success = 1;
+	repeated .CMsgClientToGCGetQuestProgressResponse.Quest quests = 2;
+}
+
+message CMsgGCToClientMatchSignedOut {
+	optional uint64 match_id = 1;
+}
+
+message CMsgGCGetHeroStatsHistory {
+	optional uint32 hero_id = 1;
+}
+
+message CMsgGCGetHeroStatsHistoryResponse {
+	optional uint32 hero_id = 1;
+	repeated .CMsgDOTASDOHeroStatsHistory records = 2;
+}
+
+message CMsgClientToGCPrivateChatInvite {
+	optional string private_chat_channel_name = 1;
+	optional uint32 invited_account_id = 2;
+}
+
+message CMsgClientToGCPrivateChatKick {
+	optional string private_chat_channel_name = 1;
+	optional uint32 kick_account_id = 2;
+}
+
+message CMsgClientToGCPrivateChatPromote {
+	optional string private_chat_channel_name = 1;
+	optional uint32 promote_account_id = 2;
+}
+
+message CMsgClientToGCPrivateChatDemote {
+	optional string private_chat_channel_name = 1;
+	optional uint32 demote_account_id = 2;
+}
+
+message CMsgGCToClientPrivateChatResponse {
+	enum Result {
+		SUCCESS = 0;
+		FAILURE_CREATION_LOCK = 1;
+		FAILURE_SQL_TRANSACTION = 2;
+		FAILURE_SDO_LOAD = 3;
+		FAILURE_NO_PERMISSION = 4;
+		FAILURE_ALREADY_MEMBER = 5;
+		FAILURE_NOT_A_MEMBER = 7;
+		FAILURE_NO_REMAINING_ADMINS = 8;
+		FAILURE_NO_ROOM = 9;
+		FAILURE_CREATION_RATE_LIMITED = 10;
+		FAILURE_UNKNOWN_CHANNEL_NAME = 11;
+		FAILURE_UNKNOWN_USER = 12;
+		FAILURE_UNKNOWN_ERROR = 13;
+		FAILURE_CANNOT_KICK_ADMIN = 14;
+		FAILURE_ALREADY_ADMIN = 15;
+	}
+
+	optional string private_chat_channel_name = 1;
+	optional .CMsgGCToClientPrivateChatResponse.Result result = 2 [default = SUCCESS];
+	optional string username = 3;
+}
+
+message CMsgClientToGCPrivateChatInfoRequest {
+	optional string private_chat_channel_name = 1;
+}
+
+message CMsgGCToClientPrivateChatInfoResponse {
+	message Member {
+		optional uint32 account_id = 1;
+		optional string name = 2;
+		optional uint32 status = 3;
+	}
+
+	optional string private_chat_channel_name = 1;
+	repeated .CMsgGCToClientPrivateChatInfoResponse.Member members = 2;
+	optional uint32 creator = 3;
+	optional uint32 creation_date = 4;
+}
+
+message CMsgPlayerBehaviorReport {
+	optional uint32 account_id = 1;
+	optional uint64 match_id = 2;
+	optional uint32 seq_num = 3;
+	optional uint32 reasons = 4;
+	optional uint32 matches_in_report = 5;
+	optional uint32 matches_clean = 6;
+	optional uint32 matches_reported = 7;
+	optional uint32 matches_abandoned = 8;
+	optional uint32 reports_count = 9;
+	optional uint32 reports_parties = 10;
+	optional uint32 commend_count = 11;
+	optional uint32 end_score = 13;
+	optional bool client_acknowledged = 100;
 }
 

--- a/proto/dota_gcmessages_common.proto
+++ b/proto/dota_gcmessages_common.proto
@@ -73,7 +73,6 @@ enum EDOTAGCMsg {
 	k_EMsgGCProfileResponse = 7099;
 	k_EMsgGCPopup = 7102;
 	k_EMsgGCDOTAClearNotifySuccessfulReport = 7104;
-	k_EMsgGCGenericResult = 7108;
 	k_EMsgGCFriendPracticeLobbyListRequest = 7111;
 	k_EMsgGCFriendPracticeLobbyListResponse = 7112;
 	k_EMsgGCPracticeLobbyJoinResponse = 7113;
@@ -492,8 +491,6 @@ enum EDOTAGCMsg {
 	k_EMsgGCHasItemDefsQuery = 7566;
 	k_EMsgGCHasItemDefsResponse = 7567;
 	k_EMsgGCToGCReplayMonitorValidateReplay = 7569;
-	k_EMsgClientToGCExchangeItemsForOffering = 7570;
-	k_EMsgClientToGCExchangeItemsForOfferingResponse = 7571;
 	k_EMsgLobbyEventPoints = 7572;
 	k_EMsgGCToGCGetCustomGameTickets = 7573;
 	k_EMsgGCToGCGetCustomGameTicketsResponse = 7574;
@@ -513,7 +510,6 @@ enum EDOTAGCMsg {
 	k_EMsgClientToGCSetPartyLeader = 7588;
 	k_EMsgClientToGCCancelPartyInvites = 7589;
 	k_EMsgGCToGCMasterReloadAccount = 7590;
-	k_EMsgSQLGCToGCGrantBackpackSlots = 7591;
 	k_EMsgSQLGrantLeagueMatchToTicketHolders = 7592;
 	k_EMsgClientToGCSetAdditionalEquipsResponse = 7593;
 	k_EMsgGCToGCEmoticonUnlockNoRollback = 7594;
@@ -603,6 +599,24 @@ enum EDOTAGCMsg {
 	k_EMsgGCToGCEnsureAccountInPartyResponse = 8072;
 	k_EMsgClientToGCGetProfileTickets = 8073;
 	k_EMsgClientToGCGetProfileTicketsResponse = 8074;
+	k_EMsgGCToClientMatchGroupsVersion = 8075;
+	k_EMsgClientToGCH264Unsupported = 8076;
+	k_EMsgClientToGCRequestH264Support = 8077;
+	k_EMsgClientToGCGetQuestProgress = 8078;
+	k_EMsgClientToGCGetQuestProgressResponse = 8079;
+	k_EMsgSignOutXPCoins = 8080;
+	k_EMsgGCToClientMatchSignedOut = 8081;
+	k_EMsgGCGetHeroStatsHistory = 8082;
+	k_EMsgGCGetHeroStatsHistoryResponse = 8083;
+	k_EMsgClientToGCPrivateChatInvite = 8084;
+	k_EMsgClientToGCPrivateChatKick = 8088;
+	k_EMsgClientToGCPrivateChatPromote = 8089;
+	k_EMsgClientToGCPrivateChatDemote = 8090;
+	k_EMsgGCToClientPrivateChatResponse = 8091;
+	k_EMsgClientToGCPrivateChatInfoRequest = 8092;
+	k_EMsgGCToClientPrivateChatInfoResponse = 8093;
+	k_EMsgClientToGCLatestBehaviorReportRequest = 8095;
+	k_EMsgClientToGCLatestBehaviorReport = 8096;
 }
 
 enum ESpecialPingValue {
@@ -718,6 +732,14 @@ enum DOTAJoinLobbyResult {
 	DOTA_JOIN_RESULT_CUSTOM_GAME_INCORRECT_VERSION = 10;
 }
 
+enum SelectionPriorityType {
+	UNDEFINED = 0;
+	RADIANT = 1;
+	DIRE = 2;
+	FIRST_PICK = 3;
+	SECOND_PICK = 4;
+}
+
 enum DOTAMatchVote {
 	DOTAMatchVote_INVALID = 0;
 	DOTAMatchVote_POSITIVE = 1;
@@ -806,12 +828,19 @@ enum EEvent {
 	EVENT_ID_ORACLE_PA = 10;
 	EVENT_ID_NEW_BLOOM_2015_PREBEAST = 11;
 	EVENT_ID_FROSTIVUS = 12;
+	EVENT_ID_WINTER_MAJOR_2015 = 13;
 }
 
 enum LobbyDotaTVDelay {
 	LobbyDotaTV_10 = 0;
 	LobbyDotaTV_120 = 1;
 	LobbyDotaTV_300 = 2;
+}
+
+enum LobbyDotaPauseSetting {
+	LobbyDotaPauseSetting_Unlimited = 0;
+	LobbyDotaPauseSetting_Limited = 1;
+	LobbyDotaPauseSetting_Disabled = 2;
 }
 
 enum EMatchOutcome {
@@ -832,6 +861,8 @@ enum EDOTAGCSessionNeed {
 	k_EDOTAGCSessionNeed_UserInUIWasConnected = 103;
 	k_EDOTAGCSessionNeed_UserInUINeverConnected = 104;
 	k_EDOTAGCSessionNeed_UserTutorials = 105;
+	k_EDOTAGCSessionNeed_UserInUIWasConnectedIdle = 106;
+	k_EDOTAGCSessionNeed_UserInUINeverConnectedIdle = 107;
 	k_EDOTAGCSessionNeed_GameServerOnline = 200;
 	k_EDOTAGCSessionNeed_GameServerLocal = 201;
 	k_EDOTAGCSessionNeed_GameServerIdle = 202;
@@ -903,6 +934,10 @@ enum DOTA_COMBATLOG_TYPES {
 	DOTA_COMBATLOG_MODIFIER_REFRESH = 19;
 	DOTA_COMBATLOG_NEUTRAL_CAMP_STACK = 20;
 	DOTA_COMBATLOG_PICKUP_RUNE = 21;
+	DOTA_COMBATLOG_REVEALED_INVISIBLE = 22;
+	DOTA_COMBATLOG_HERO_SAVED = 23;
+	DOTA_COMBATLOG_MANA_RESTORED = 24;
+	DOTA_COMBATLOG_HERO_LEVELUP = 25;
 }
 
 enum DOTAChatChannelType_t {
@@ -923,6 +958,7 @@ enum DOTAChatChannelType_t {
 	DOTAChannelType_GameCoaching = 14;
 	DOTAChannelType_Cafe = 15;
 	DOTAChannelType_CustomGame = 16;
+	DOTAChannelType_Private = 17;
 }
 
 message CSODOTAGameAccountClient {
@@ -972,6 +1008,8 @@ message CSODOTAGameAccountClient {
 	optional uint32 play_time_points = 68;
 	optional uint32 account_flags = 69;
 	optional uint32 play_time_level = 70;
+	optional uint32 player_behavior_seq_num_last_report = 71;
+	optional uint32 player_behavior_score_last_report = 72;
 }
 
 message CSODOTAPartyMember {
@@ -1264,6 +1302,12 @@ message CSODOTALobby {
 	optional fixed32 custom_game_timestamp = 80;
 	repeated uint64 previous_series_matches = 81;
 	optional uint64 previous_match_override = 82;
+	optional bool custom_game_uses_account_records = 83;
+	optional uint32 league_selection_priority_team = 84;
+	optional .SelectionPriorityType league_selection_priority_choice = 85 [default = UNDEFINED];
+	optional .SelectionPriorityType league_non_selection_priority_choice = 86 [default = UNDEFINED];
+	optional uint32 game_start_time = 87;
+	optional .LobbyDotaPauseSetting pause_setting = 88 [default = LobbyDotaPauseSetting_Unlimited];
 }
 
 message CMsgLobbyEventPoints {
@@ -1283,10 +1327,6 @@ message CMsgLobbyEventPoints {
 	repeated .CMsgLobbyEventPoints.AccountPoints account_points = 2;
 }
 
-message CMsgDOTAGenericResult {
-	optional uint32 eresult = 1 [default = 2];
-}
-
 message CMsgDOTABroadcastNotification {
 	optional string message = 1;
 }
@@ -1295,22 +1335,6 @@ message CMsgDOTAPCBangTimedReward {
 	optional string persona = 1;
 	optional uint32 itemdef = 2;
 	optional string pcbangname = 3;
-}
-
-message CAttribute_String {
-	optional string value = 1;
-}
-
-message CAttribute_ItemDynamicRecipeComponent {
-	optional uint32 item_def = 1;
-	optional uint32 item_quality = 2;
-	optional uint32 item_flags = 3;
-	optional string attributes_string = 4;
-	optional uint32 item_count = 5;
-	optional uint32 items_fulfilled = 6;
-	optional uint32 item_rarity = 7;
-	optional string lootlist = 8;
-	optional uint64 fulfilled_item_id = 9;
 }
 
 message CProtoItemHeroStatue {
@@ -1332,69 +1356,6 @@ message CProtoItemTeamShowcase {
 	repeated uint32 wearable = 5;
 	optional string inscription = 6;
 	repeated uint32 style = 7;
-}
-
-message CProtoItemSocket {
-	optional uint64 item_id = 1;
-	optional uint32 attr_def_index = 2;
-	optional uint32 required_type = 3;
-	optional string required_hero = 4;
-	optional uint32 gem_def_index = 5;
-	optional bool not_tradable = 6;
-	optional string required_item_slot = 7;
-}
-
-message CProtoItemSocket_Empty {
-	optional .CProtoItemSocket socket = 1;
-}
-
-message CProtoItemSocket_Effect {
-	optional .CProtoItemSocket socket = 1;
-	optional uint32 effect = 2;
-}
-
-message CProtoItemSocket_Color {
-	optional .CProtoItemSocket socket = 1;
-	optional uint32 red = 2;
-	optional uint32 green = 3;
-	optional uint32 blue = 4;
-}
-
-message CProtoItemSocket_Strange {
-	optional .CProtoItemSocket socket = 1;
-	optional uint32 strange_type = 2;
-	optional uint32 strange_value = 3;
-}
-
-message CProtoItemSocket_Spectator {
-	optional .CProtoItemSocket socket = 1;
-	optional uint32 games_viewed = 2;
-	optional uint32 corporation_id = 3;
-	optional uint32 league_id = 4;
-	optional uint32 team_id = 5;
-}
-
-message CProtoItemSocket_AssetModifier {
-	optional .CProtoItemSocket socket = 1;
-	optional uint32 asset_modifier = 2;
-}
-
-message CProtoItemSocket_AssetModifier_DESERIALIZE_FROM_STRING_ONLY {
-	optional .CProtoItemSocket socket = 1;
-	optional uint32 asset_modifier = 2;
-	optional uint32 anim_modifier = 3;
-	optional uint32 ability_effect = 4;
-}
-
-message CProtoItemSocket_Autograph {
-	optional .CProtoItemSocket socket = 1;
-	optional string autograph = 2;
-	optional uint32 autograph_id = 3;
-	optional uint32 autograph_score = 4;
-}
-
-message CProtoItemSocket_StaticVisuals {
-	optional .CProtoItemSocket socket = 1;
 }
 
 message CMatchPlayerAbilityUpgrade {
@@ -1536,6 +1497,12 @@ message CMsgDOTARedeemItem {
 }
 
 message CMsgDOTARedeemItemResponse {
+	enum EResultCode {
+		k_Succeeded = 0;
+		k_Failed = 1;
+	}
+
+	optional .CMsgDOTARedeemItemResponse.EResultCode response = 1 [default = k_Succeeded];
 }
 
 message CMsgDOTACombatLogEntry {
@@ -1579,6 +1546,14 @@ message CMsgDOTACombatLogEntry {
 	optional uint32 neutral_camp_type = 38;
 	optional uint32 rune_type = 39;
 	repeated uint32 assist_players = 40;
+	optional bool is_heal_save = 41;
+	optional bool is_ultimate_ability = 42;
+	optional uint32 attacker_hero_level = 43;
+	optional uint32 target_hero_level = 44;
+	optional uint32 xpm = 45;
+	optional uint32 gpm = 46;
+	optional uint32 event_location = 47;
+	optional bool target_is_self = 48;
 }
 
 message CMsgDOTAProfileCard {
@@ -1644,6 +1619,7 @@ message CMsgGCToClientNewBloomTimingUpdated {
 message CSODOTAPlayerChallenge {
 	enum EFlags {
 		eFlag_InstantRerollUncompleted = 1;
+		eFlag_QuestChallenge = 2;
 	}
 
 	optional uint32 account_id = 1 [(key_field) = true];
@@ -1657,6 +1633,8 @@ message CSODOTAPlayerChallenge {
 	optional uint32 sequence_id = 9;
 	optional uint32 challenge_tier = 10;
 	optional uint32 flags = 11;
+	optional uint32 attempts = 12;
+	optional uint32 complete_limit = 13;
 }
 
 message CMsgClientToGCRerollPlayerChallenge {
@@ -1678,6 +1656,7 @@ message CMsgGCRerollPlayerChallengeResponse {
 
 message CMsgGCTopCustomGamesList {
 	repeated uint64 top_custom_games = 1;
+	optional uint64 game_of_the_day = 2;
 }
 
 message CMsgDOTARealtimeGameStats {
@@ -1914,5 +1893,22 @@ message CMsgDOTARealtimeGameStatsTerse {
 	repeated .CMsgDOTARealtimeGameStatsTerse.BuildingDetails buildings = 3;
 	optional .CMsgDOTARealtimeGameStatsTerse.GraphData graph_data = 4;
 	optional bool delta_frame = 5;
+}
+
+message CMsgGCToClientMatchGroupsVersion {
+	optional uint32 matchgroups_version = 1;
+}
+
+message CMsgDOTASDOHeroStatsHistory {
+	optional uint64 match_id = 1;
+	optional uint32 game_mode = 2;
+	optional uint32 lobby_type = 3;
+	optional uint32 start_time = 4;
+	optional bool won = 5;
+	optional uint32 gpm = 6;
+	optional uint32 xpm = 7;
+	optional uint32 kills = 8;
+	optional uint32 deaths = 9;
+	optional uint32 assists = 10;
 }
 

--- a/proto/econ_gcmessages.proto
+++ b/proto/econ_gcmessages.proto
@@ -10,9 +10,7 @@ enum EGCItemMsg {
 	k_EMsgGCCraftResponse = 1003;
 	k_EMsgGCDelete = 1004;
 	k_EMsgGCVerifyCacheSubscription = 1005;
-	k_EMsgGCNameItem = 1006;
-	k_EMsgGCUnlockCrate = 1007;
-	k_EMsgGCUnlockCrateResponse = 1008;
+	k_EMsgClientToGCNameItem = 1006;
 	k_EMsgGCPaintItem = 1009;
 	k_EMsgGCPaintItemResponse = 1010;
 	k_EMsgGCGoldenWrenchBroadcast = 1011;
@@ -36,14 +34,10 @@ enum EGCItemMsg {
 	k_EMsgGCRemoveItemPaint = 1031;
 	k_EMsgGCUnwrapGiftRequest = 1037;
 	k_EMsgGCUnwrapGiftResponse = 1038;
-	k_EMsgGCSetItemStyle = 1039;
+	k_EMsgGCSetItemStyle_DEPRECATED = 1039;
 	k_EMsgGCUsedClaimCodeItem = 1040;
 	k_EMsgGCSortItems = 1041;
 	k_EMsgGC_RevolvingLootList_DEPRECATED = 1042;
-	k_EMsgGCLookupAccount = 1043;
-	k_EMsgGCLookupAccountResponse = 1044;
-	k_EMsgGCLookupAccountName = 1045;
-	k_EMsgGCLookupAccountNameResponse = 1046;
 	k_EMsgGCUpdateItemSchema = 1049;
 	k_EMsgGCRemoveCustomTexture = 1051;
 	k_EMsgGCRemoveCustomTextureResponse = 1052;
@@ -58,10 +52,8 @@ enum EGCItemMsg {
 	k_EMsgGCItemAcknowledged = 1062;
 	k_EMsgGCPresets_SelectPresetForClass = 1063;
 	k_EMsgGCPresets_SetItemPosition = 1064;
-	k_EMsgGC_ReportAbuse = 1065;
-	k_EMsgGC_ReportAbuseResponse = 1066;
 	k_EMsgGCPresets_SelectPresetForClassReply = 1067;
-	k_EMsgGCNameItemNotification = 1068;
+	k_EMsgClientToGCNameItemResponse = 1068;
 	k_EMsgGCApplyConsumableEffects = 1069;
 	k_EMsgGCConsumableExhausted = 1070;
 	k_EMsgGCShowItemsPickedUp = 1071;
@@ -96,6 +88,7 @@ enum EGCItemMsg {
 	k_EMsgClientToGCRemoveItemGifterAttributes = 1109;
 	k_EMsgClientToGCRemoveItemName = 1110;
 	k_EMsgClientToGCRemoveItemDescription = 1111;
+	k_EMsgClientToGCRemoveItemAttributeResponse = 1112;
 	k_EMsgGCTradingBase = 1500;
 	k_EMsgGCTrading_InitiateTradeRequest = 1501;
 	k_EMsgGCTrading_InitiateTradeResponse = 1502;
@@ -180,6 +173,12 @@ enum EGCItemMsg {
 	k_EMsgClientToGCUnlockCrate = 2574;
 	k_EMsgClientToGCUnlockCrateResponse = 2575;
 	k_EMsgClientToGCUnpackBundle = 2576;
+	k_EMsgClientToGCSetItemStyle = 2577;
+	k_EMsgClientToGCSetItemStyleResponse = 2578;
+	k_EMsgGCGenericResult = 2579;
+	k_EMsgSQLGCToGCGrantBackpackSlots = 2580;
+	k_EMsgClientToGCLookupAccountName = 2581;
+	k_EMsgClientToGCLookupAccountNameResponse = 2582;
 }
 
 enum EGCMsgResponse {
@@ -274,10 +273,11 @@ message CMsgRequestItemPurgatory_FinalizePurchase {
 
 message CMsgRequestItemPurgatory_FinalizePurchaseResponse {
 	optional uint32 result = 1;
+	repeated uint64 item_ids = 2;
 }
 
 message CMsgRequestItemPurgatory_RefundPurchase {
-	optional uint64 item_id = 1;
+	repeated uint64 item_ids = 1;
 }
 
 message CMsgRequestItemPurgatory_RefundPurchaseResponse {
@@ -358,7 +358,12 @@ message CMsgRequestCrateItems {
 }
 
 message CMsgRequestCrateItemsResponse {
-	optional uint32 crate_item_def = 1;
+	enum EResult {
+		k_Succeeded = 0;
+		k_Failed = 1;
+	}
+
+	optional uint32 response = 1;
 	repeated uint32 item_defs = 2;
 }
 
@@ -458,8 +463,13 @@ message CMsgGCPartnerBalanceResponse {
 	optional uint32 balance = 2;
 }
 
+message CGCStoreRechargeRedirect_LineItem {
+	optional uint32 item_def_id = 1;
+	optional uint32 quantity = 2;
+}
+
 message CMsgGCPartnerRechargeRedirectURLRequest {
-	optional uint32 def_index = 1;
+	repeated .CGCStoreRechargeRedirect_LineItem line_items = 1;
 }
 
 message CMsgGCPartnerRechargeRedirectURLResponse {
@@ -486,7 +496,15 @@ message CMsgRedeemCode {
 }
 
 message CMsgRedeemCodeResponse {
+	enum EResultCode {
+		k_Succeeded = 0;
+		k_Failed_CodeNotFound = 1;
+		k_Failed_CodeAlreadyUsed = 2;
+		k_Failed_OtherError = 3;
+	}
+
 	optional uint32 response = 1;
+	optional uint64 item_id = 2;
 }
 
 message CMsgDevNewItemRequest {
@@ -557,6 +575,21 @@ message CMsgClientToGCEquipItemsResponse {
 	optional fixed64 so_cache_version_id = 1;
 }
 
+message CMsgClientToGCSetItemStyle {
+	optional uint64 item_id = 1;
+	optional uint32 style_index = 2;
+}
+
+message CMsgClientToGCSetItemStyleResponse {
+	enum ESetStyle {
+		k_SetStyle_Succeeded = 0;
+		k_SetStyle_Failed = 1;
+		k_SetStyle_Failed_StyleIsLocked = 2;
+	}
+
+	optional .CMsgClientToGCSetItemStyleResponse.ESetStyle response = 1 [default = k_SetStyle_Succeeded];
+}
+
 message CMsgClientToGCUnlockItemStyle {
 	optional uint64 item_to_unlock = 1;
 	optional uint32 style_index = 2;
@@ -574,6 +607,9 @@ message CMsgClientToGCUnlockItemStyleResponse {
 		k_UnlockStyle_Failed_CantAffordGem = 6;
 		k_UnlockStyle_Failed_NoCompendiumLevel = 7;
 		k_UnlockStyle_Failed_AlreadyUnlocked = 8;
+		k_UnlockStyle_Failed_OtherError = 9;
+		k_UnlockStyle_Failed_ItemIsInvalid = 10;
+		k_UnlockStyle_Failed_ToolIsInvalid = 11;
 	}
 
 	optional .CMsgClientToGCUnlockItemStyleResponse.EUnlockStyle response = 1 [default = k_UnlockStyle_Succeeded];
@@ -604,18 +640,159 @@ message CMsgClientToGCUnlockCrateResponse {
 	repeated .CMsgClientToGCUnlockCrateResponse.Item granted_items = 2;
 }
 
-message CMsgGCRemoveItemAttributeMsg {
+message CMsgClientToGCRemoveItemAttribute {
 	optional uint64 item_id = 1;
 }
 
-message CMsgGCNameItem {
+message CMsgClientToGCRemoveItemAttributeResponse {
+	enum ERemoveItemAttribute {
+		k_RemoveItemAttribute_Succeeded = 0;
+		k_RemoveItemAttribute_Failed = 1;
+		k_RemoveItemAttribute_Failed_ItemIsInvalid = 2;
+		k_RemoveItemAttribute_Failed_AttributeCannotBeRemoved = 3;
+		k_RemoveItemAttribute_Failed_AttributeDoesntExist = 4;
+	}
+
+	optional .CMsgClientToGCRemoveItemAttributeResponse.ERemoveItemAttribute response = 1 [default = k_RemoveItemAttribute_Succeeded];
+	optional uint64 item_id = 2;
+}
+
+message CMsgClientToGCNameItem {
 	optional uint64 subject_item_id = 1;
 	optional uint64 tool_item_id = 2;
 	optional string name = 3;
 }
 
+message CMsgClientToGCNameItemResponse {
+	enum ENameItem {
+		k_NameItem_Succeeded = 0;
+		k_NameItem_Failed = 1;
+		k_NameItem_Failed_ToolIsInvalid = 2;
+		k_NameItem_Failed_ItemIsInvalid = 3;
+		k_NameItem_Failed_NameIsInvalid = 4;
+	}
+
+	optional .CMsgClientToGCNameItemResponse.ENameItem response = 1 [default = k_NameItem_Succeeded];
+	optional uint64 item_id = 2;
+}
+
 message CMsgGCSetItemPosition {
 	optional uint64 item_id = 1;
 	optional uint32 new_position = 2;
+}
+
+message CAttribute_ItemDynamicRecipeComponent {
+	optional uint32 item_def = 1;
+	optional uint32 item_quality = 2;
+	optional uint32 item_flags = 3;
+	optional string attributes_string = 4;
+	optional uint32 item_count = 5;
+	optional uint32 items_fulfilled = 6;
+	optional uint32 item_rarity = 7;
+	optional string lootlist = 8;
+	optional uint64 fulfilled_item_id = 9;
+}
+
+message CProtoItemSocket {
+	optional uint64 item_id = 1;
+	optional uint32 attr_def_index = 2;
+	optional uint32 required_type = 3;
+	optional string required_hero = 4;
+	optional uint32 gem_def_index = 5;
+	optional bool not_tradable = 6;
+	optional string required_item_slot = 7;
+}
+
+message CProtoItemSocket_Empty {
+	optional .CProtoItemSocket socket = 1;
+}
+
+message CProtoItemSocket_Effect {
+	optional .CProtoItemSocket socket = 1;
+	optional uint32 effect = 2;
+}
+
+message CProtoItemSocket_Color {
+	optional .CProtoItemSocket socket = 1;
+	optional uint32 red = 2;
+	optional uint32 green = 3;
+	optional uint32 blue = 4;
+}
+
+message CProtoItemSocket_Strange {
+	optional .CProtoItemSocket socket = 1;
+	optional uint32 strange_type = 2;
+	optional uint32 strange_value = 3;
+}
+
+message CProtoItemSocket_Spectator {
+	optional .CProtoItemSocket socket = 1;
+	optional uint32 games_viewed = 2;
+	optional uint32 corporation_id = 3;
+	optional uint32 league_id = 4;
+	optional uint32 team_id = 5;
+}
+
+message CProtoItemSocket_AssetModifier {
+	optional .CProtoItemSocket socket = 1;
+	optional uint32 asset_modifier = 2;
+}
+
+message CProtoItemSocket_AssetModifier_DESERIALIZE_FROM_STRING_ONLY {
+	optional .CProtoItemSocket socket = 1;
+	optional uint32 asset_modifier = 2;
+	optional uint32 anim_modifier = 3;
+	optional uint32 ability_effect = 4;
+}
+
+message CProtoItemSocket_Autograph {
+	optional .CProtoItemSocket socket = 1;
+	optional string autograph = 2;
+	optional uint32 autograph_id = 3;
+	optional uint32 autograph_score = 4;
+}
+
+message CProtoItemSocket_StaticVisuals {
+	optional .CProtoItemSocket socket = 1;
+}
+
+message CAttribute_String {
+	optional string value = 1;
+}
+
+message CWorkshop_GetItemDailyRevenue_Request {
+	optional uint32 appid = 1;
+	optional uint32 item_id = 2;
+	optional uint32 date_start = 3;
+	optional uint32 date_end = 4;
+}
+
+message CWorkshop_GetItemDailyRevenue_Response {
+	message CountryDailyRevenue {
+		optional string country_code = 1;
+		optional uint32 date = 2;
+		optional int64 revenue_usd = 3;
+		optional int32 units = 4;
+	}
+
+	repeated .CWorkshop_GetItemDailyRevenue_Response.CountryDailyRevenue country_revenue = 1;
+}
+
+message CMsgGenericResult {
+	optional uint32 eresult = 1 [default = 2];
+}
+
+message CMsgSQLGCToGCGrantBackpackSlots {
+	optional uint32 account_id = 1;
+	optional uint32 add_slots = 2;
+}
+
+message CMsgClientToGCLookupAccountName {
+	optional uint32 account_id = 1;
+}
+
+message CMsgClientToGCLookupAccountNameResponse {
+	optional uint32 account_id = 1;
+	optional string account_name = 2;
 }
 

--- a/proto/gcsdk_gcmessages.proto
+++ b/proto/gcsdk_gcmessages.proto
@@ -22,6 +22,7 @@ enum GCConnectionStatus {
 	GCConnectionStatus_NO_SESSION_IN_LOGON_QUEUE = 3;
 	GCConnectionStatus_NO_STEAM = 4;
 	GCConnectionStatus_SUSPENDED = 5;
+	GCConnectionStatus_STEAM_GOING_DOWN = 6;
 }
 
 message CMsgSHA1Digest {

--- a/proto/steammessages.proto
+++ b/proto/steammessages.proto
@@ -366,6 +366,13 @@ message CGCSystemMsg_GetAccountDetails_Response {
 	optional uint32 steam_level = 23;
 	optional uint32 friend_count = 24;
 	optional uint32 account_creation_time = 25;
+	optional bool is_steamguard_enabled = 27;
+	optional bool is_phone_verified = 28;
+	optional bool is_two_factor_auth_enabled = 29;
+	optional uint32 two_factor_enabled_time = 30;
+	optional uint32 phone_verification_time = 31;
+	optional uint64 phone_id = 33;
+	optional bool is_phone_identifying = 34;
 }
 
 message CMsgGCGetPersonaNames {

--- a/update_proto.sh
+++ b/update_proto.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 pushd proto
 rm *.proto
 wget https://raw.githubusercontent.com/SteamDatabase/GameTracking/master/Protobufs/dota/base_gcmessages.proto


### PR DESCRIPTION
Oops, only 28 days behind schedule.

We have a huge number of bug fixes ranging from small to critical and nice functionality enhancements.

The major two changes that are not backwards compatible, that I recall are:

* The `chatJoin` and `chatLeave` events were changed to return the channel name instead of the id. All debug logs pertaining chat channels will now mention chat channel instead of IDs.
* The `waitTimesByGroup` argument in the `matchmakingStatsData` event has been removed.

This super-cedes PR https://github.com/RJacksonm1/node-dota2/pull/172 because I wanted to do this safely without the nasty rebase of last time... so we retain full history of commits this time!