### PR TITLE
example2.js missing steam_guard_code

### DIFF
--- a/examples/example2.js
+++ b/examples/example2.js
@@ -153,6 +153,7 @@ var logOnDetails = {
     "account_name": global.config.steam_user,
     "password": global.config.steam_pass,
 };
+if (global.config.steam_guard_code) logOnDetails.auth_code = global.config.steam_guard_code;
 
 try {
     var sentry = fs.readFileSync('sentry');


### PR DESCRIPTION
Added missing steam_guard_code/auth_code to example file for 4.0.