### PR TITLE
Updated example2.js to save hashed sentry

### DIFF
--- a/examples/example2.js
+++ b/examples/example2.js
@@ -143,10 +143,11 @@ onSteamError = function onSteamError(error) {
 };
 
 steamUser.on('updateMachineAuth', function(sentry, callback) {
-    fs.writeFileSync('sentry', sentry.bytes)
+    var hashedSentry = crypto.createHash('sha1').update(sentry.bytes).digest();
+    fs.writeFileSync('sentry', hashedSentry)
     util.log("sentryfile saved");
 
-    callback({ sha_file: crypto.createHash('sha1').update(sentry.bytes).digest() });
+    callback({ sha_file: hashedSentry});
 });
 
 var logOnDetails = {


### PR DESCRIPTION
This makes sense right?

`  var sentry = fs.readFileSync('sentry');`
 `if (sentry.length) logOnDetails.sha_sentryfile = sentry;`

Seems to want a hashed sentryfile. Anyways logging in works with this modification.