### PR TITLE
Turn type proto message id into proto name

### DIFF
--- a/handlers/helper.js
+++ b/handlers/helper.js
@@ -121,3 +121,17 @@ Dota2._convertCallback = function(handler, callback) {
         return undefined;
     }
 };
+
+Dota2._getMessageName = function(kMsg) {
+    //k_EMsgClientToGCGetProfileCard
+    var msgTypes = ["EDOTAGCMsg", "EGCSystemMsg", "ESOMsg", "EGCBaseClientMsg", "EGCToGCMsg", "EGCEconBaseMsg"];
+    for (var i=0; i<msgTypes.length; i++) {
+        for (var m in Dota2.schema[msgTypes[i]]) {
+            if (Dota2.schema[msgTypes[i]].hasOwnProperty(m)) {
+                if (Dota2.schema[msgTypes[i]][m] === kMsg) {
+                    return m;
+                }
+            }
+        }
+    }
+}

--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ var Dota2Client = function Dota2Client(steamClient, debug, debugMore) {
         callback = callback || null;
 
         var kMsg = header.msg;
-        if (self.debugMore) util.log("Dota2 fromGC: " + kMsg); // TODO:  Turn type-protoMask into key name.
+        if (self.debugMore) util.log("Dota2 fromGC: " + Dota2._getMessageName(kMsg));
 
         if (kMsg in self._handlers) {
             if (callback) {

--- a/test/test.js
+++ b/test/test.js
@@ -87,6 +87,12 @@ var steam = require("steam"),
 		var calculated_steam_id = Dota2.ToSteamID(GABE_ACCOUNT_ID);
 		should(calculated_steam_id.toString()).equal(GABE_STEAM_ID);
 	};
+	
+	var invertKMsgTypeID = function() {
+		var msg_type_id = "k_EMsgClientToGCGetProfileCard";
+		var calculated_msg_type_id = dota2._getMessageName(dota2.schema.EDOTAGCMsg.k_EMsgClientToGCGetProfileCard);
+		should(calculated_msg_type_id).equal(msg_type_id);
+	}
  
 	// Tests
 	describe('Steam', function() {
@@ -121,6 +127,10 @@ var steam = require("steam"),
 		});
 		
 		describe('Utilities', function () {
+			describe('#ToTypeID', function () {
+				it('should convert an enum to the corresponding message type ID ', invertKMsgTypeID);
+			});
+			
 			describe('#ToAccountID', function () {
 				it('should convert a 64-bit Steam ID into a 32-bit account ID', convertSteamIDToAccountID);
 			});


### PR DESCRIPTION
Very old feature request. When you activate additional debugging, the print-out will now show the name of the prototype instead of the ID.