### PR TITLE
Fix #304 chat channels with same name

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,9 +106,9 @@ Attempts to delete an item. Requires the GC to be ready (listen for the `ready` 
 ### Chat
 **_Limited Steam accounts cannot interact with chat!_**
 
-#### joinChat(channel, [type])
-* `channel` - A string for the channel name.
-* `[type]` - The type of the channel being joined.  Defaults to `Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom`.
+#### joinChat(channel_name, [channel_type])
+* `channel_name` - A string for the channel name.
+* `[channel_type]` - The type of the channel being joined.  Defaults to `Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom`.
 
 Joins a chat channel. If the chat channel with the given name doesn't exist, it 
 is created. Listen for the `chatMessage` event for other people's chat messages.
@@ -117,28 +117,35 @@ Notable channels:
 * `Guild_##########` - The chat channel of the guild with guild_id = ##########
 * `Lobby_##########` - The chat channel of the lobby with lobby_id = ##########
 
-#### leaveChat(channel)
-* `channel` - A string for the channel name.
+#### leaveChat(channel_name, [channel_type])
+* `channel_name` - A string for the channel name.
+* `[channel_type]` - The type of the channel you want to leave. Use the `Dota2.schema.DOTAChatChannelType_t` enum. 
 
-Leaves a chat channel.
+Leaves a chat channel. If you've joined different channels with the same name, specify the type to prevent unexpected behaviour.
 
-#### sendMessage(channel, message)
+#### sendMessage(channel, message, [channel_type])
 * `channel` - A string for the channel name.
 * `message` - The message you want to send.
+* `[channel_type]` - The type of the channel you want to send a message to. Use the `Dota2.schema.DOTAChatChannelType_t` enum.
 
 Sends a message to the specified chat channel. Won't send if you're not in the channel you try to send to.
+If you've joined different channels with the same name, specify the type to prevent unexpected behaviour.
 
-#### flipCoin(channel)
+#### flipCoin(channel, [channel_type])
 * `channel` - A string for the channel name.
+* `[channel_type]` - The type of the channel you want to flip a coin in. Use the `Dota2.schema.DOTAChatChannelType_t` enum. 
 
 Sends a coin flip to the specified chat channel. Won't send if you're not in the channel you try to send to.
+If you've joined different channels with the same name, specify the type to prevent unexpected behaviour.
 
-#### rollDice(channel, min, max)
+#### rollDice(channel, min, max, [channel_type])
 * `channel` - A string for the channel name.
 * `min` - Lower bound of the dice roll.
 * `max` - Upper bound of the dice roll.
+* `[channel_type]` - The type of the channel you want to roll a dice in. Use the `Dota2.schema.DOTAChatChannelType_t` enum. 
 
 Sends a dice roll to the specified chat channel. Won't send if you're not in the channel you try to send to.
+If you've joined different channels with the same name, specify the type to prevent unexpected behaviour.
 
 #### requestChatChannels()
 

--- a/handlers/chat.js
+++ b/handlers/chat.js
@@ -2,12 +2,15 @@ var Dota2 = require("../index"),
     util = require("util");
 
 // Methods
-Dota2.Dota2Client.prototype._getChannelByName = function(channel_name) {
+Dota2.Dota2Client.prototype._getChannelByName = function(channel_name, channel_type) {
     // Returns the channel corresponding to the given channel_name
     if (this.chatChannels) {
         return this.chatChannels.filter(
             function(item) {
-                return (item.channel_name === channel_name);
+                if(channel_type >= 0)
+                    return (item.channel_name === channel_name && item.channel_type === channel_type);
+                else
+                    return (item.channel_name === channel_name);
             }
         )[0];
     } else {
@@ -29,24 +32,24 @@ Dota2.Dota2Client.prototype._getChannelById = function(channel_id) {
     }
 }
 
-Dota2.Dota2Client.prototype.joinChat = function(channel, type) {
-    type = type || Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom;
+Dota2.Dota2Client.prototype.joinChat = function(channel_name, channel_type) {
+    channel_type = channel_type || Dota2.schema.DOTAChatChannelType_t.DOTAChannelType_Custom;
 
     /* Attempts to join a chat channel.  Expect k_EMsgGCJoinChatChannelResponse from GC */
-    if (this.debug) util.log("Joining chat channel: " + channel);
+    if (this.debug) util.log("Joining chat channel: " + channel_name);
     
     var payload = new Dota2.schema.CMsgDOTAJoinChatChannel({
-        "channel_name": channel,
-        "channel_type": type
+        "channel_name": channel_name,
+        "channel_type": channel_type
     });
     this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCJoinChatChannel, payload);
 };
 
-Dota2.Dota2Client.prototype.leaveChat = function(channel) {
+Dota2.Dota2Client.prototype.leaveChat = function(channel_name, channel_type) {
     /* Attempts to leave a chat channel. GC does not send a response. */
-    if (this.debug) util.log("Leaving chat channel: " + channel);
+    if (this.debug) util.log("Leaving chat channel: " + channel_name);
     // Clear cache
-    var cache = this._getChannelByName(channel);
+    var cache = this._getChannelByName(channel_name, channel_type);
     if (cache === undefined) {
         if (this.debug) util.log("Cannot leave a channel you have not joined.");
         return;
@@ -58,11 +61,11 @@ Dota2.Dota2Client.prototype.leaveChat = function(channel) {
     this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCLeaveChatChannel, payload);
 };
 
-Dota2.Dota2Client.prototype.sendMessage = function(channel, message) {
+Dota2.Dota2Client.prototype.sendMessage = function(channel_name, message, channel_type) {
     /* Attempts to send a message to a chat channel. GC does not send a response. */
-    if (this.debug) util.log("Sending message to " + channel);
+    if (this.debug) util.log("Sending message to " + channel_name);
     // Check cache
-    var cache = this._getChannelByName(channel);
+    var cache = this._getChannelByName(channel_name, channel_type);
     if (cache === undefined) {
         if (this.debug) util.log("Cannot send message to a channel you have not joined.");
         return;
@@ -75,11 +78,11 @@ Dota2.Dota2Client.prototype.sendMessage = function(channel, message) {
     this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage, payload);
 };
 
-Dota2.Dota2Client.prototype.shareLobby = function(channel) {
+Dota2.Dota2Client.prototype.shareLobby = function(channel_name, channel_type) {
     /* Attempts to send a message to a chat channel. GC does not send a response. */
-    if (this.debug) util.log("Sharing lobby to " + channel);
+    if (this.debug) util.log("Sharing lobby to " + channel_name);
     // Check cache
-    var cache = this._getChannelByName(channel);
+    var cache = this._getChannelByName(channel_name, channel_type);
     if (cache === undefined) {
         if (this.debug) util.log("Cannot send message to a channel you have not joined.");
         return;
@@ -97,11 +100,11 @@ Dota2.Dota2Client.prototype.shareLobby = function(channel) {
     this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage, payload);
 };
 
-Dota2.Dota2Client.prototype.flipCoin = function(channel) {
+Dota2.Dota2Client.prototype.flipCoin = function(channel_name, channel_type) {
     /* Attempts to send a coin flip to a chat channel. Expect a chatmessage in response. */
-    if (this.debug) util.log("Sending coin flip to " + channel);
+    if (this.debug) util.log("Sending coin flip to " + channel_name);
     // Check cache
-    var cache = this._getChannelByName(channel);
+    var cache = this._getChannelByName(channel_name, channel_type);
     if (cache === undefined) {
         if (this.debug) util.log("Cannot send message to a channel you have not joined.");
         return;
@@ -114,11 +117,11 @@ Dota2.Dota2Client.prototype.flipCoin = function(channel) {
     this.sendToGC(Dota2.schema.EDOTAGCMsg.k_EMsgGCChatMessage, payload);
 };
 
-Dota2.Dota2Client.prototype.rollDice = function(channel, min, max) {
+Dota2.Dota2Client.prototype.rollDice = function(channel_name, min, max, channel_type) {
     /* Attempts to send a dice roll to a chat channel. Expect a chatmessage in response. */
-    if (this.debug) util.log("Sending dice roll to " + channel);
+    if (this.debug) util.log("Sending dice roll to " + channel_name);
     // Check cache
-    var cache = this._getChannelByName(channel);
+    var cache = this._getChannelByName(channel_name, channel_type);
     if (cache === undefined) {
         if (this.debug) util.log("Cannot send message to a channel you have not joined.");
         return;


### PR DESCRIPTION
Added an optional parameter channel_type to the chat functions and updated the README. If present it is taken into account, if not we ignore the type and return the first result found