### PR TITLE
Update development dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,8 +9,8 @@
     "steam": "^1.2.0"
   },
   "devDependencies": {
-    "mocha": "^2.5.3",
-    "should": "^8.4.0"
+    "mocha": "^3.0.2",
+    "should": "^11.0.0"
   },
   "scripts": {
     "update": "bash update_proto.sh",


### PR DESCRIPTION
These updates shouldn't impact test results (against master they pass). Against staging the tests are failing right now anyway due to an unrelated error, it seems.